### PR TITLE
Adding the missing dB_Sun parameter.

### DIFF
--- a/vires/vires/data/range_types.json
+++ b/vires/vires/data/range_types.json
@@ -114,6 +114,16 @@
             "color_interpretation": "Undefined",
             "data_type": "Float64",
             "definition": "",
+            "description": "Sun induced stray magnetic field correction vector subtracted from measurements, VFM frame",
+            "identifier": "dB_Sun",
+            "name": "dB_Sun",
+            "nil_values": [],
+            "uom": "nT"
+        },
+        {
+            "color_interpretation": "Undefined",
+            "data_type": "Float64",
+            "definition": "",
             "description": "Magnetic stray field correction vector of AOCS magneto-torquer coils, VFM frame",
             "identifier": "dB_AOCS",
             "name": "dB_AOCS",

--- a/vires/vires/management/commands/vires_rangetype_load.py
+++ b/vires/vires/management/commands/vires_rangetype_load.py
@@ -49,9 +49,22 @@ class Command(eoxs_rangetype_load.Command):
                 "are used."
             )
         ),
+        make_option(
+            '--do-not-update', dest='update',
+            action='store_false', default=True,
+            help=(
+                "This option prevents the script from updating the existing "
+                "range-types. By default the existing range-types get updated "
+                "automatically."
+            )
+        ),
     )
 
     help = (
         "Load range-types stored in JSON file or from the default package's \n"
-        "range type definitions stores in: \n\t%s" % RANGE_TYPES
+        "range type definitions stores in: \n    %s\n\n"
+        "If the any of the loaded range-types already exists in the data-base\n"
+        "than this range-type gets updated. The default automatic range-type\n"
+        "update can be prevented with the '--do-not-update' option."
+        "" % RANGE_TYPES
     )

--- a/vires/vires/processes/retrieve_data.py
+++ b/vires/vires/processes/retrieve_data.py
@@ -80,8 +80,8 @@ REQUIRED_FIELDS = [
 
 DROPPED_FIELDS = [
     "B_VFM", "SyncStatus", "q_NEC_CRF", "Att_error", "Flags_F", "Flags_B",
-    "Flags_q", "Flags_Platform", "ASM_Freq_Dev", "dB_AOCS", "dB_other",
-    "dF_AOCS", "dF_other"
+    "Flags_q", "Flags_Platform", "ASM_Freq_Dev", "dB_Sun", "dB_AOCS",
+    "dB_other", "dF_AOCS", "dF_other"
 ]
 
 CDF_RAW_TIME_CONVERTOR = {


### PR DESCRIPTION
This pull request solves #28, namely:
- adds the `dB_Sun` 'band' the the `SWARM_MAG` range type
- updates the range type loader to allow range type updates (enabled this feature recently introduced to the EOxServer) 

Notes:
- The download WPS process copies all range 'bands' from the source products, i.e., no code change is needed.
- Since none of the other `dB_*` parameters is fetched to the client it is is assumed the this is also case of the `dB_Sun` parameter.
