### PR TITLE
Support for MMA_SHA_2F product.

### DIFF
--- a/vires/setup.cfg
+++ b/vires/setup.cfg
@@ -27,5 +27,5 @@
 
 [bdist_rpm]
 release=1
-requires=EOxServer >= 0.4 python-matplotlib eoxmagmod >= 0.5.0
+requires=EOxServer >= 0.4 python-matplotlib eoxmagmod >= 0.5.1
 provides=VirES-Server

--- a/vires/setup.py
+++ b/vires/setup.py
@@ -40,7 +40,7 @@ setup(
     package_data={'vires': ['data/*.json']},
     scripts=[],
     install_requires=[
-        'EOxServer', 'eoxmagmod>=0.5.0',
+        'EOxServer', 'eoxmagmod>=0.5.1',
     ],
     zip_safe=False,
 

--- a/vires/vires/cached_products.py
+++ b/vires/vires/cached_products.py
@@ -42,7 +42,7 @@ class InvalidSourcesError(ValueError):
     pass
 
 
-def update_cached_product(sources, destination, updater,
+def update_cached_product(sources, destination, updater, filter_=None,
                           tmp_extension=None, logger=None):
     """ Update cached file from the given source using the provided
     updater subroutine.
@@ -52,6 +52,9 @@ def update_cached_product(sources, destination, updater,
     tmp_extension '.tmp' to '.tmp.cdf'.
     """
     logger = logger or getLogger(__name__)
+
+    if filter_:
+        sources = filter_(sources)
 
     logger.info("Updating %s from %s", destination, ", ".join(
         source if source != '-' else '<standard input>'

--- a/vires/vires/cached_products.py
+++ b/vires/vires/cached_products.py
@@ -1,0 +1,90 @@
+#-------------------------------------------------------------------------------
+#
+# Cached product management utilities.
+#
+# Authors: Martin Paces <martin.paces@eox.at>
+#-------------------------------------------------------------------------------
+# Copyright (C) 2018 EOX IT Services GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies of this Software or works derived from this Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#-------------------------------------------------------------------------------
+
+from sys import stdin
+from os import rename, remove
+from os.path import exists
+from shutil import copyfileobj
+from contextlib import closing
+from urllib2 import urlopen
+
+# URL time-out in seconds
+URL_TIMEOUT = 25
+
+
+def update_cached_product(source, destination, updater, label=None,
+                          tmp_extension=None):
+    """ Update cached file from the given source using the provided
+    updater subroutine.
+    The optional label can contain the name of the updated product.
+
+    NOTE: When the cached product is stored as CDF then change the default
+    tmp_extension '.tmp' to '.tmp.cdf'.
+    """
+    print "Updating %s from %s" % (
+        label or destination, source if source != '-' else '<standard input>'
+    )
+
+    temporary_file = destination + (tmp_extension or ".tmp")
+    remove_if_exists(temporary_file)
+
+    try:
+        if is_url(source):
+            with closing(urlopen(source, timeout=URL_TIMEOUT)) as fin:
+                updater(fin, temporary_file)
+        elif source == '-':
+            updater(stdin, temporary_file)
+        else:
+            with open(source) as fin:
+                updater(fin, temporary_file)
+        rename(temporary_file, destination)
+    except Exception:
+        remove_if_exists(temporary_file)
+        raise
+
+
+def remove_if_exists(filename):
+    """ Remove file if it exists. """
+    if exists(filename):
+        remove(filename)
+
+
+def is_url(source):
+    """ Return true if the source is a URL. """
+    return (
+        source.startswith("https://") or
+        source.startswith("http://") or
+        source.startswith("ftp://")
+    )
+
+
+def copy_file(file_in, destination):
+    """ Read content from the input file object and copy it to the destination
+    path without modification.
+    """
+    with file(destination, "wb") as file_out:
+        copyfileobj(file_in, file_out, 1024*1024)

--- a/vires/vires/forward_models/swarm_shc.py
+++ b/vires/vires/forward_models/swarm_shc.py
@@ -32,6 +32,8 @@ from eoxmagmod import (
     load_model_shc,
     load_model_swarm_mma_2c_internal,
     load_model_swarm_mma_2c_external,
+    load_model_swarm_mma_2f_geo_internal,
+    load_model_swarm_mma_2f_geo_external,
     load_model_swarm_mio_internal,
     load_model_swarm_mio_external,
 )
@@ -109,6 +111,32 @@ class SwarmMMA2CSecondaryForwardModel(SwarmL2SHCForwardModel):
     @cached_property
     def model(self):
         return load_model_swarm_mma_2c_internal(
+            settings.VIRES_CACHED_PRODUCTS[self.product_type]
+        )
+
+
+class SwarmMMA2FPrimaryForwardModel(SwarmL2SHCForwardModel):
+    """ Swarm L2 MMA_SHA_2F product primary field model.
+    """
+    product_type = "MMA_SHA_2F"
+    identifier = "MMA_SHA_2F-Primary"
+
+    @cached_property
+    def model(self):
+        return load_model_swarm_mma_2f_geo_external(
+            settings.VIRES_CACHED_PRODUCTS[self.product_type]
+        )
+
+
+class SwarmMMA2FSecondaryForwardModel(SwarmL2SHCForwardModel):
+    """ Swarm L2 MMA_SHA_2F product secondary field model.
+    """
+    product_type = "MMA_SHA_2F"
+    identifier = "MMA_SHA_2F-Secondary"
+
+    @cached_property
+    def model(self):
+        return load_model_swarm_mma_2f_geo_internal(
             settings.VIRES_CACHED_PRODUCTS[self.product_type]
         )
 

--- a/vires/vires/management/commands/vires_update_cached_product.py
+++ b/vires/vires/management/commands/vires_update_cached_product.py
@@ -31,7 +31,7 @@ from django.core.management.base import BaseCommand, CommandError
 from eoxserver.resources.coverages.management.commands import CommandOutputMixIn
 from vires.aux import update_kp, update_dst
 from vires.orbit_counter import update_orbit_counter_file
-from vires.model_mma import update_mma_sha_2f
+from vires.model_mma import update_mma_sha_2f, filter_mma_sha_2f
 from vires.cached_products import (
     copy_file, update_cached_product, simple_cached_product_updater,
     InvalidSourcesError,
@@ -58,6 +58,7 @@ class Command(CommandOutputMixIn, BaseCommand):
                 sources=source,
                 destination=product_info["filename"],
                 updater=product_info.get("updater", copy_file),
+                filter_=product_info.get("filter"),
                 tmp_extension=product_info.get("tmp_extension"),
                 logger=getLogger(__name__)
             )
@@ -76,6 +77,7 @@ CACHED_PRODUCTS = {
 if "MMA_SHA_2F" in CACHED_PRODUCTS:
     CACHED_PRODUCTS["MMA_SHA_2F"].update({
         "updater": update_mma_sha_2f,
+        "filter": filter_mma_sha_2f,
         "tmp_extension": ".tmp.cdf",
     })
 

--- a/vires/vires/management/commands/vires_update_cached_product.py
+++ b/vires/vires/management/commands/vires_update_cached_product.py
@@ -31,6 +31,7 @@ from django.core.management.base import BaseCommand, CommandError
 from eoxserver.resources.coverages.management.commands import CommandOutputMixIn
 from vires.aux import update_kp, update_dst
 from vires.orbit_counter import update_orbit_counter_file
+from vires.model_mma import update_mma_sha_2f
 from vires.cached_products import (
     copy_file, update_cached_product, simple_cached_product_updater,
     InvalidSourcesError,
@@ -72,6 +73,12 @@ CACHED_PRODUCTS = {
 }
 
 # custom cached products
+if "MMA_SHA_2F" in CACHED_PRODUCTS:
+    CACHED_PRODUCTS["MMA_SHA_2F"].update({
+        "updater": update_mma_sha_2f,
+        "tmp_extension": ".tmp.cdf",
+    })
+
 CACHED_PRODUCTS.update({
     "AUXAORBCNT": {
         "filename": settings.VIRES_ORBIT_COUNTER_DB['A'],

--- a/vires/vires/management/commands/vires_update_cached_product.py
+++ b/vires/vires/management/commands/vires_update_cached_product.py
@@ -1,8 +1,8 @@
 #-------------------------------------------------------------------------------
 #
-# Project: EOxServer <http://eoxserver.org>
-# Authors: Martin Paces <martin.paces@eox.at>
+# Cached product management command.
 #
+# Authors: Martin Paces <martin.paces@eox.at>
 #-------------------------------------------------------------------------------
 # Copyright (C) 2018 EOX IT Services GmbH
 #
@@ -25,14 +25,12 @@
 # THE SOFTWARE.
 #-------------------------------------------------------------------------------
 
-from shutil import copyfileobj
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from eoxserver.resources.coverages.management.commands import CommandOutputMixIn
+from vires.aux import update_kp, update_dst
 from vires.orbit_counter import update_orbit_counter_file
-from vires.management.commands.vires_update_aux import (
-    update, update_dst, update_kp,
-)
+from vires.cached_products import copy_file, update_cached_product
 
 
 class Command(CommandOutputMixIn, BaseCommand):
@@ -50,18 +48,13 @@ class Command(CommandOutputMixIn, BaseCommand):
 
     def handle(self, product_type, source, **kwargs):
         product_info = CACHED_PRODUCTS[product_type]
-        update(
+        update_cached_product(
             source=source,
             destination=product_info["filename"],
-            updater=product_info.get("updater", self.default_updater),
+            updater=product_info.get("updater", copy_file),
             label=product_info.get("label", "%s product" % product_type),
             tmp_extension=product_info.get("tmp_extension"),
         )
-
-    @staticmethod
-    def default_updater(file_in, destination):
-        with file(destination, "wb") as file_out:
-            copyfileobj(file_in, file_out, 1024*1024)
 
 
 # load the default cached products

--- a/vires/vires/management/commands/vires_update_orbit_counter.py
+++ b/vires/vires/management/commands/vires_update_orbit_counter.py
@@ -31,7 +31,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from eoxserver.resources.coverages.management.commands import CommandOutputMixIn
 from vires.orbit_counter import update_orbit_counter_file
-from vires.management.commands.vires_update_aux import update
+from vires.cached_products import update_cached_product
 
 
 class Command(CommandOutputMixIn, BaseCommand):
@@ -72,7 +72,7 @@ class Command(CommandOutputMixIn, BaseCommand):
     def handle(self, *args, **kwargs):
         for opt_name, destination, label in self.options:
             if kwargs[opt_name] is not None:
-                update(
+                update_cached_product(
                     kwargs[opt_name], destination,
                     update_orbit_counter_file, label,
                     tmp_extension=".tmp.cdf"

--- a/vires/vires/model_mma.py
+++ b/vires/vires/model_mma.py
@@ -35,11 +35,16 @@ MMA_SHA_2F_TIME_VARIABLE = "t_qs"
 MMA_SHA_2F_VARIABLES = ["t_qs", "qs_geo", "t_gh", "gh_geo"]
 
 
-def update_mma_sha_2f(sources, destination):
-    """ Update cached MMA_SHA_2F product. """
-    sources = filter_and_sort_sources(
+def filter_mma_sha_2f(sources):
+    """ Filter and sort the input MMA_SHA_2F products. """
+    return filter_and_sort_sources(
         sources, MMA_SHA_2F_TIME_VARIABLE, MMA_SHA_2F_MAX_ALLOWED_TIME_GAP
     )
+
+
+def update_mma_sha_2f(sources, destination):
+    """ Update cached MMA_SHA_2F product. """
+    sources = filter_mma_sha_2f(sources)
     models = list(_load_models(sources, MMA_SHA_2F_VARIABLES))
     create_merged_mma_sha_2f(destination, sources, models)
 

--- a/vires/vires/model_mma.py
+++ b/vires/vires/model_mma.py
@@ -1,0 +1,138 @@
+#-------------------------------------------------------------------------------
+#
+# MMA products handling
+#
+# Authors: Martin Paces <martin.paces@eox.at>
+#
+#-------------------------------------------------------------------------------
+# Copyright (C) 2018 EOX IT Services GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies of this Software or works derived from this Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#-------------------------------------------------------------------------------
+
+from os.path import basename
+from numpy import concatenate
+from .cdf_util import cdf_open
+
+MMA_SHA_2F_MAX_ALLOWED_TIME_GAP = 7200000 # ms (2 hours)
+MMA_SHA_2F_TIME_VARIABLE = "t_qs"
+MMA_SHA_2F_VARIABLES = ["t_qs", "qs_geo", "t_gh", "gh_geo"]
+
+
+def update_mma_sha_2f(sources, destination):
+    """ Update cached MMA_SHA_2F product. """
+    sources = filter_and_sort_sources(
+        sources, MMA_SHA_2F_TIME_VARIABLE, MMA_SHA_2F_MAX_ALLOWED_TIME_GAP
+    )
+    models = list(_load_models(sources, MMA_SHA_2F_VARIABLES))
+    create_merged_mma_sha_2f(destination, sources, models)
+
+
+def create_merged_mma_sha_2f(destination, sources, models):
+    """ Create blank MMA_SHA_2F product file.
+    """
+    def _create_empty_mma_sha_2f(cdf_dst, cdf_src):
+        _copy_attributes(cdf_dst, cdf_src)
+        cdf_dst.attrs["TITLE"] = "Merged " + str(cdf_src.attrs["TITLE"])
+        _set_variable(
+            cdf_dst, cdf_src, "t_qs", _merge_variable(models, "t_qs", axis=1)
+        )
+        _copy_variable(cdf_dst, cdf_src, "nm_qs")
+        _set_variable(
+            cdf_dst, cdf_src, "qs_geo", _merge_variable(models, "qs_geo", axis=1)
+        )
+        _set_variable(
+            cdf_dst, cdf_src, "t_gh", _merge_variable(models, "t_gh", axis=1)
+        )
+        _copy_variable(cdf_dst, cdf_src, "nm_gh")
+        _set_variable(
+            cdf_dst, cdf_src, "gh_geo", _merge_variable(models, "gh_geo", axis=1)
+        )
+
+    with cdf_open(destination, "w") as cdf_dst:
+        with cdf_open(sources[-1], "r") as cdf_src:
+            _create_empty_mma_sha_2f(cdf_dst, cdf_src)
+        set_sources(cdf_dst, sources)
+
+
+def filter_and_sort_sources(sources, time_variable, max_gap):
+    """ Sort sources by validity and filter adjacent consecutive products. """
+
+    def _sortable_sources(sources):
+        for source in sources:
+            start, stop = _read_validity(source, time_variable)
+            yield start, stop, source
+
+    def _filter_sources(sources):
+        start_last, stop_last, source = sources.next()
+        yield start_last, stop_last, source
+        for start, stop, source in sources:
+            if stop >= start_last:
+                continue
+            elif start_last - stop <= max_gap:
+                yield start, stop, source
+                start_last, stop_last = start, stop
+            else:
+                break
+
+    sorted_sources = sorted(_sortable_sources(sources), reverse=True)
+    filtered_sources = list(_filter_sources(iter(sorted_sources)))
+    return [source for _, _, source in reversed(filtered_sources)]
+
+
+def set_sources(cdf_dst, sources):
+    """ Set attribute containing list of source files. """
+    cdf_dst.attrs["SOURCES"] = [basename(source) for source in sources]
+
+
+def _read_validity(source, time_variable):
+    with cdf_open(source, "r") as cdf_src:
+        time = cdf_src.raw_var(time_variable)[...].squeeze()
+        return time[0], time[-1]
+
+
+def _load_models(sources, variables):
+    def _load_model(cdf_src, variables):
+        return {
+            variable: cdf_src.raw_var(variable)[...] for variable in variables
+        }
+
+    for source in sources:
+        with cdf_open(source, "r") as cdf_src:
+            yield _load_model(cdf_src, variables)
+
+
+def _merge_variable(models, variable, axis=0):
+    return concatenate([model[variable] for model in models], axis=axis)
+
+
+def _set_variable(cdf_dst, cdf_src, variable, data):
+    raw_var = cdf_src.raw_var(variable)
+    cdf_dst.new(variable, data, raw_var.type())
+    cdf_dst[variable].attrs.update(raw_var.attrs)
+
+
+def _copy_variable(cdf_dst, cdf_src, variable):
+    raw_var = cdf_src.raw_var(variable)
+    cdf_dst.new(variable, raw_var[...], raw_var.type())
+    cdf_dst[variable].attrs.update(raw_var.attrs)
+
+
+def _copy_attributes(cdf_dst, cdf_src):
+    cdf_dst.attrs.update(cdf_src.attrs)

--- a/vires/vires/processes/util/magnetic_models.py
+++ b/vires/vires/processes/util/magnetic_models.py
@@ -41,6 +41,8 @@ from eoxmagmod import (
     load_model_emm,
     load_model_swarm_mma_2c_internal,
     load_model_swarm_mma_2c_external,
+    load_model_swarm_mma_2f_geo_internal,
+    load_model_swarm_mma_2f_geo_external,
     load_model_swarm_mio_internal,
     load_model_swarm_mio_external,
 )
@@ -88,6 +90,8 @@ CACHED_MODEL_LOADERS = {
     "MLI_SHA_2D": load_model_shc,
     "MMA_SHA_2C-Primary": load_model_swarm_mma_2c_external,
     "MMA_SHA_2C-Secondary": load_model_swarm_mma_2c_internal,
+    "MMA_SHA_2F-Primary": load_model_swarm_mma_2f_geo_external,
+    "MMA_SHA_2F-Secondary": load_model_swarm_mma_2f_geo_internal,
     "MIO_SHA_2C-Primary": load_model_swarm_mio_external,
     "MIO_SHA_2C-Secondary": load_model_swarm_mio_internal,
     "MIO_SHA_2D-Primary": load_model_swarm_mio_external,
@@ -97,6 +101,8 @@ CACHED_MODEL_LOADERS = {
 MODEL_SOURCES = {
     "MMA_SHA_2C-Primary": "MMA_SHA_2C",
     "MMA_SHA_2C-Secondary": "MMA_SHA_2C",
+    "MMA_SHA_2F-Primary": "MMA_SHA_2F",
+    "MMA_SHA_2F-Secondary": "MMA_SHA_2F",
     "MIO_SHA_2C-Primary": "MIO_SHA_2C",
     "MIO_SHA_2C-Secondary": "MIO_SHA_2C",
     "MIO_SHA_2D-Primary": "MIO_SHA_2D",


### PR DESCRIPTION
This PR completes the support for the Swarm L2 SHA product by adding the last outstanding MMA_SHA_2F product type.

The MMA_SHA_2F model is split to several half-year (small) product file. In order to reuse the existing model handling without modification, the applicable MMA_SHA_2F parts are merged into one cached model file (which is still smaller then, e.g., the equivalent MMA_SHA_2C model file).

The cached file update was re-worked to accept multiple inputs.



