### PR TITLE
Upgrading the Chaos6-Core model to the latest available one.

### DIFF
--- a/vires/setup.py
+++ b/vires/setup.py
@@ -40,7 +40,7 @@ setup(
     package_data={'vires': ['data/*.json']},
     scripts=[],
     install_requires=[
-        'EOxServer', 'eoxmagmod>=0.5.0',
+        'EOxServer', 'eoxmagmod>=0.5.3',
     ],
     zip_safe=False,
 

--- a/vires/vires/forward_models/chaos6.py
+++ b/vires/vires/forward_models/chaos6.py
@@ -28,7 +28,7 @@
 #-------------------------------------------------------------------------------
 
 from eoxmagmod import load_model_shc, load_model_shc_combined
-from eoxmagmod.data import CHAOS6_CORE_X3, CHAOS6_STATIC
+from eoxmagmod.data import CHAOS6_CORE_LATEST, CHAOS6_STATIC
 from vires.forward_models.base import BaseForwardModel
 from vires.util import cached_property
 
@@ -40,7 +40,7 @@ class CHAOS6CoreForwardModel(BaseForwardModel):
 
     @cached_property
     def model(self):
-        return load_model_shc(CHAOS6_CORE_X3)
+        return load_model_shc(CHAOS6_CORE_LATEST)
 
 
 class CHAOS6StaticForwardModel(BaseForwardModel):
@@ -60,7 +60,7 @@ class CHAOS6CombinedForwardModel(BaseForwardModel):
 
     @cached_property
     def model(self):
-        return load_model_shc_combined(CHAOS6_CORE_X3, CHAOS6_STATIC)
+        return load_model_shc_combined(CHAOS6_CORE_LATEST, CHAOS6_STATIC)
 
 
 class CHAOSCoreForwardModel(CHAOS6CoreForwardModel):

--- a/vires/vires/processes/util/magnetic_models.py
+++ b/vires/vires/processes/util/magnetic_models.py
@@ -29,7 +29,7 @@
 from os.path import exists
 from django.conf import settings
 from eoxmagmod.data import (
-    CHAOS5_CORE_V4, CHAOS5_STATIC, CHAOS6_CORE_X3, CHAOS6_STATIC,
+    CHAOS5_CORE_V4, CHAOS5_STATIC, CHAOS6_CORE_LATEST, CHAOS6_STATIC,
     WMM_2010, WMM_2015, EMM_2010_STATIC, EMM_2010_SECVAR,
     IGRF11, IGRF12, SIFM,
 )
@@ -59,9 +59,9 @@ MODELS_FACTORIES = {
     "EMM2010":
         lambda: load_model_emm(EMM_2010_STATIC, EMM_2010_SECVAR),
     "CHAOS-6-Combined":
-        lambda: load_model_shc_combined(CHAOS6_CORE_X3, CHAOS6_STATIC),
+        lambda: load_model_shc_combined(CHAOS6_CORE_LATEST, CHAOS6_STATIC),
     "CHAOS-6-Core":
-        lambda: load_model_shc(CHAOS6_CORE_X3),
+        lambda: load_model_shc(CHAOS6_CORE_LATEST),
     "CHAOS-6-Static":
         lambda: load_model_shc(CHAOS6_STATIC),
     "CHAOS-5-Combined":


### PR DESCRIPTION
This change is needed to automatically use the latest available Chaos6-Core model.