### PR TITLE
Basic support for the TEC Asolute_VTEC and Elevation_Angle.

### DIFF
--- a/vires/vires/data/range_types.json
+++ b/vires/vires/data/range_types.json
@@ -1339,11 +1339,31 @@
             "color_interpretation": "Undefined",
             "data_type": "Float64",
             "definition": "",
-            "description": "Absolute slant TE",
+            "description": "Absolute slant TEC",
             "identifier": "Absolute_STEC",
             "name": "Absolute_STEC",
             "nil_values": [],
             "uom": "TECU"
+        },
+        {
+            "color_interpretation": "Undefined",
+            "data_type": "Float64",
+            "definition": "",
+            "description": "Absolute vertical TEC",
+            "identifier": "Absolute_VTEC",
+            "name": "Absolute_VTEC",
+            "nil_values": [],
+            "uom": "TECU"
+        },
+        {
+            "color_interpretation": "Undefined",
+            "data_type": "Float64",
+            "definition": "",
+            "description": "Elevation Angle",
+            "identifier": "Elevation_Angle",
+            "name": "Elevation_Angle",
+            "nil_values": [],
+            "uom": "degree"
         },
         {
             "color_interpretation": "Undefined",


### PR DESCRIPTION
This PR adds basic support for the TEC products `Absolute_VTEC` and `Elevation_Angle` variables. (https://github.com/ESA-VirES/WebClient-Framework/issues/283)