### PR TITLE
Hot-fix: eoxs_allauth initial migration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 *.pyc
 *.egg-info/
-eoxs_allauth/eoxs_allauth/migrations/

--- a/eoxs_allauth/eoxs_allauth/migrations/0001_initial.py
+++ b/eoxs_allauth/eoxs_allauth/migrations/0001_initial.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+import django_countries.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='UserProfile',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('title', models.CharField(max_length=100, blank=True)),
+                ('institution', models.CharField(max_length=100, blank=True)),
+                ('country', django_countries.fields.CountryField(blank=True, max_length=2)),
+                ('study_area', models.CharField(max_length=200, blank=True)),
+                ('executive_summary', models.CharField(max_length=3000, blank=True)),
+                ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]


### PR DESCRIPTION
Production hot-fix adding missing initial migration to `eoxs_allauth` Django app.

This patch must be applied **before the v3.0.0 production deployment**.

The patch requires manual `manage.py migrate --fake-initial`
