### PR TITLE
Hotfix: CHAOS-7

### DIFF
--- a/vires/setup.py
+++ b/vires/setup.py
@@ -46,7 +46,7 @@ setup(
     },
     scripts=[],
     install_requires=[
-        'EOxServer', 'eoxmagmod>=0.9.5',
+        'EOxServer', 'eoxmagmod>=0.9.6',
     ],
     zip_safe=False,
 


### PR DESCRIPTION
This PR fixes the server-side CHAOS model evaluation after the release of the CHAOS-7 model.

requires also upgrade of the magnetic model library https://github.com/ESA-VirES/MagneticModel/pull/28