### PR TITLE
Hotfix: MAGx_HR_1B registration

### DIFF
--- a/vires/vires/cdf_util.py
+++ b/vires/vires/cdf_util.py
@@ -44,7 +44,7 @@ from . import FULL_PACKAGE_NAME
 from .util import full
 from .time_util import (
     mjd2000_to_decimal_year, year_to_day2k, days_per_year,
-    datetime, naive_to_utc,
+    datetime, naive_to_utc, utc_to_naive,
 )
 
 GZIP_COMPRESSION = pycdf.const.GZIP_COMPRESSION
@@ -231,7 +231,7 @@ def datetime_to_cdf_rawtime(time, cdf_type):
 
 def datetime_to_cdf_epoch(dtobj):
     """ Convert raw CDF_EPOCH values to datetime.datetime object. """
-    return (dtobj - DATETIME_1970).total_seconds()*1e3  + CDF_EPOCH_1970
+    return (utc_to_naive(dtobj) - DATETIME_1970).total_seconds()*1e3  + CDF_EPOCH_1970
 
 
 def cdf_rawtime_to_datetime(raw_time, cdf_type):

--- a/vires/vires/cdf_util.py
+++ b/vires/vires/cdf_util.py
@@ -29,7 +29,7 @@
 #-------------------------------------------------------------------------------
 
 from os.path import exists
-from datetime import timedelta
+from datetime import datetime, timedelta
 import ctypes
 from numpy import (
     nan, vectorize, object as dt_object, float64 as dt_float64,
@@ -104,6 +104,7 @@ CDF_TYPE_TO_DTYPE = {
     CDF_CHAR_TYPE: "S",
 }
 
+DATETIME_1970 = datetime(1970, 1, 1)
 CDF_EPOCH_1970 = 62167219200000.0
 CDF_EPOCH_2000 = 63113904000000.0
 
@@ -223,9 +224,14 @@ def datetime_to_cdf_rawtime(time, cdf_type):
     """ Convert `datetime.datetime` object to CDF raw time. """
     if cdf_type == CDF_EPOCH_TYPE:
         if isinstance(time, ndarray):
-            return pycdf.lib.v_datetime_to_epoch(time)
-        return pycdf.lib.datetime_to_epoch(time)
+            return vectorize(datetime_to_cdf_epoch)(time)
+        return datetime_to_cdf_epoch(time)
     raise TypeError("Unsupported CDF time type %r !" % cdf_type)
+
+
+def datetime_to_cdf_epoch(dtobj):
+    """ Convert raw CDF_EPOCH values to datetime.datetime object. """
+    return (dtobj - DATETIME_1970).total_seconds()*1e3  + CDF_EPOCH_1970
 
 
 def cdf_rawtime_to_datetime(raw_time, cdf_type):
@@ -234,9 +240,14 @@ def cdf_rawtime_to_datetime(raw_time, cdf_type):
     """
     if cdf_type == CDF_EPOCH_TYPE:
         if isinstance(raw_time, ndarray):
-            return pycdf.lib.v_epoch_to_datetime(raw_time)
-        return pycdf.lib.epoch_to_datetime(raw_time)
+            return vectorize(cdf_epoch_to_datetime)(raw_time)
+        return cdf_epoch_to_datetime(raw_time)
     raise TypeError("Unsupported CDF time type %r !" % cdf_type)
+
+
+def cdf_epoch_to_datetime(cdf_epoch):
+    """ Convert raw CDF_EPOCH values to datetime.datetime object. """
+    return DATETIME_1970 + timedelta(milliseconds=(cdf_epoch - CDF_EPOCH_1970))
 
 
 def cdf_rawtime_to_unix_epoch(raw_time, cdf_type):

--- a/vires/vires/tests/cdf_util.py
+++ b/vires/vires/tests/cdf_util.py
@@ -38,7 +38,7 @@ from numpy import (
 )
 from scipy.interpolate import interp1d
 from spacepy import pycdf
-
+from django.utils.timezone import get_fixed_timezone, utc
 from vires.time_util import (
     datetime_to_mjd2000, datetime_to_unix_epoch, datetime_to_decimal_year,
 )
@@ -120,7 +120,42 @@ class TestCDFEpochTimeBaseline(ArrayMixIn, unittest.TestCase):
             datetime_to_cdf_rawtime(input_, CDF_EPOCH_TYPE), expected
         )
 
+    def test_datetime_tzaware_to_cdf_rawtime_subms_scalar(self):
+        self.assertEqual(
+            datetime_to_cdf_rawtime(
+                datetime(2014, 6, 19, 23, 59, 59, 979984, utc), CDF_EPOCH_TYPE
+            ), 63570441599979.984
+        )
 
+    def test_datetime_tzaware_to_cdf_rawtime_subms_midnight_scalar(self):
+        self.assertEqual(
+            datetime_to_cdf_rawtime(
+                datetime(2014, 6, 19, 22, 59, 59, 999984, get_fixed_timezone(-60)),
+                CDF_EPOCH_TYPE
+            ), 63570441599999.984
+        )
+
+    def test_datetime_tzaware_to_cdf_rawtime_subms_array(self):
+        input_ = array([
+            [
+                datetime(2014, 6, 19, 23, 59, 59, 939984, utc),
+                datetime(2014, 6, 19, 23, 59, 59, 959984, utc),
+            ],
+            [
+                datetime(2014, 6, 19, 22, 59, 59, 979984, get_fixed_timezone(-60)),
+                datetime(2014, 6, 20, 0, 59, 59, 999984, get_fixed_timezone(+60)),
+            ],
+        ])
+        expected = array([
+            [63570441599939.984, 63570441599959.984],
+            [63570441599979.984, 63570441599999.984],
+        ])
+        self.assertAllEqual(
+            datetime_to_cdf_rawtime(input_, CDF_EPOCH_TYPE), expected
+        )
+
+
+from django.utils.timezone import get_fixed_timezone, utc
 class TestCDFEpochTime00(ArrayMixIn, unittest.TestCase):
     FILE = "./test_tmp_cdf_epoch2.cdf"
     START = datetime(1980, 1, 1, 0, 0, 0)

--- a/vires/vires/tests/cdf_util.py
+++ b/vires/vires/tests/cdf_util.py
@@ -54,6 +54,73 @@ from vires.tests.aux_dst import TEST_DST, DATA_DST
 from vires.tests import ArrayMixIn
 
 
+class TestCDFEpochTimeBaseline(ArrayMixIn, unittest.TestCase):
+
+    def test_cdf_rawtime_to_datetime_subms_scalar(self):
+        self.assertEqual(
+            cdf_rawtime_to_datetime(63570441599979.984, CDF_EPOCH_TYPE),
+            datetime(2014, 6, 19, 23, 59, 59, 979984)
+        )
+
+    def test_cdf_rawtime_to_datetime_subms_midnight_scalar(self):
+        self.assertEqual(
+            cdf_rawtime_to_datetime(63570441599999.984, CDF_EPOCH_TYPE),
+            datetime(2014, 6, 19, 23, 59, 59, 999984)
+        )
+
+    def test_cdf_rawtime_to_datetime_subms_array(self):
+        input_ = array([
+            [63570441599939.984, 63570441599959.984],
+            [63570441599979.984, 63570441599999.984],
+        ])
+        expected = array([
+            [
+                datetime(2014, 6, 19, 23, 59, 59, 939984),
+                datetime(2014, 6, 19, 23, 59, 59, 959984),
+            ],
+            [
+                datetime(2014, 6, 19, 23, 59, 59, 979984),
+                datetime(2014, 6, 19, 23, 59, 59, 999984),
+            ],
+        ])
+        self.assertAllEqual(
+            cdf_rawtime_to_datetime(input_, CDF_EPOCH_TYPE), expected
+        )
+
+    def test_datetime_to_cdf_rawtime_subms_scalar(self):
+        self.assertEqual(
+            datetime_to_cdf_rawtime(
+                datetime(2014, 6, 19, 23, 59, 59, 979984), CDF_EPOCH_TYPE
+            ), 63570441599979.984
+        )
+
+    def test_datetime_to_cdf_rawtime_subms_midnight_scalar(self):
+        self.assertEqual(
+            datetime_to_cdf_rawtime(
+                datetime(2014, 6, 19, 23, 59, 59, 999984), CDF_EPOCH_TYPE
+            ), 63570441599999.984
+        )
+
+    def test_datetime_to_cdf_rawtime_subms_array(self):
+        input_ = array([
+            [
+                datetime(2014, 6, 19, 23, 59, 59, 939984),
+                datetime(2014, 6, 19, 23, 59, 59, 959984),
+            ],
+            [
+                datetime(2014, 6, 19, 23, 59, 59, 979984),
+                datetime(2014, 6, 19, 23, 59, 59, 999984),
+            ],
+        ])
+        expected = array([
+            [63570441599939.984, 63570441599959.984],
+            [63570441599979.984, 63570441599999.984],
+        ])
+        self.assertAllEqual(
+            datetime_to_cdf_rawtime(input_, CDF_EPOCH_TYPE), expected
+        )
+
+
 class TestCDFEpochTime00(ArrayMixIn, unittest.TestCase):
     FILE = "./test_tmp_cdf_epoch2.cdf"
     START = datetime(1980, 1, 1, 0, 0, 0)

--- a/vires/vires/time_util.py
+++ b/vires/vires/time_util.py
@@ -32,7 +32,7 @@ import re
 import math
 import time
 from datetime import datetime, timedelta
-from django.utils.dateparse import utc
+from django.utils.timezone import utc
 
 DT_1970 = datetime(1970, 1, 1)
 DT_2000 = datetime(2000, 1, 1)


### PR DESCRIPTION
Fixing `CDF_EPOCH` to `datetime` conversion and product metadata extraction. (#140)