### PR TITLE
Hotfix: django-allauth compatibility

### DIFF
--- a/vires_oauth/vires_oauth/context_processors.py
+++ b/vires_oauth/vires_oauth/context_processors.py
@@ -29,7 +29,7 @@
 from django.conf import settings
 
 def vires_oauth(request):
-    permissions = request.user.oauth_user_permissions
+    permissions = getattr(request.user, 'oauth_user_permissions', ())
     return {
         "vires_apps": [
             app for app in getattr(settings, "VIRES_APPS", []) if (


### PR DESCRIPTION
The oauth server deployed in production requires a minor correction to work with the latest django-allauth versions.