### PR TITLE
Hotfix: changing CHAOS-7 to CHAOS-8.

### DIFF
--- a/eoxs_allauth/eoxs_allauth/templates/vires/workspace.html
+++ b/eoxs_allauth/eoxs_allauth/templates/vires/workspace.html
@@ -539,7 +539,7 @@
               13th generation of the International Geomagnetic Reference Field (<a target="_blank" href="https://earth-planets-space.springeropen.com/articles/10.1186/s40623-020-01288-x">IGRF 13</a>) released in December 2019 by the International Association of Geomagnetism and Aeronomy
             </li>
             <li style="list-style-type: circle;">
-              The latest version of the CHAOS high resolution geomagnetic field model derived from Swarm, CHAMP, Ørsted, SAC-C and CryoSat-2 satellite magnetic data along with ground observatory data (<a target="_blank" href="https://spacecenter.dk/files/magnetic-models/CHAOS-7/">CHAOS-7</a>)
+              The latest version of the CHAOS high resolution geomagnetic field model derived from Swarm, MSS-1, CSES, CryoSat-2, CHAMP, SAC-C, and Ørsted satellite magnetic data along with ground observatory data (<a target="_blank" href="https://spacecenter.dk/files/magnetic-models/CHAOS-8/">CHAOS-8</a>)
             </li>
             <li style="list-style-type: circle;">
               Spherical harmonic model of the main (core) field and its temporal variation (<a target="_blank" href="https://swarmhandbook.earth.esa.int/catalogue/SW_MCO_SHA_2C">MCO_SHA_2C</a>)


### PR DESCRIPTION
Changing reference from CHAOS-7 to the new CHAOS-8 model.

See also https://github.com/ESA-VirES/WebClient-Framework/pull/488