### PR TITLE
production release (VirES v3.15.0)

### DIFF
--- a/eoxs_allauth/eoxs_allauth/templates/documents/changelog.html
+++ b/eoxs_allauth/eoxs_allauth/templates/documents/changelog.html
@@ -4,6 +4,23 @@
 <h1>Changelog</h1>
 <hr>
 <h3>
+    Release of Service v3.15.0 (2024-12-20)
+</h3>
+<p>
+    Features:
+</p>
+<ul>
+    <li><b>IGRF-14</b><br>
+        The IGRF model has been upgraded to the latest 14th generation.
+        This update also affects calculation of the magnetic coordinates
+        (dipole, quasi-dipole and magnetic local time).
+    </li>
+    <li><b>CHAOS-8</b><br>
+        The CHAOS model has been upgraded to the latest version 8.
+    </li>
+</ul>
+<hr>
+<h3>
     Release of Service v3.14.1 (2024-09-03)
 </h3>
 <p>

--- a/eoxs_allauth/eoxs_allauth/templates/vires/workspace.html
+++ b/eoxs_allauth/eoxs_allauth/templates/vires/workspace.html
@@ -286,8 +286,8 @@
       </div>
 
         <p class="lead current-version text-center">
-          <strong>Version 3.14.1</strong> (<a href="/changelog">Changelog</a>)<br>
-          <em>September 2024</em>
+          <strong>Version 3.15.0</strong> (<a href="/changelog">Changelog</a>)<br>
+          <em>December 2024</em>
         </p>
 
         <p class="lead text-center">

--- a/eoxs_allauth/eoxs_allauth/templates/vires/workspace.html
+++ b/eoxs_allauth/eoxs_allauth/templates/vires/workspace.html
@@ -536,7 +536,7 @@
           <p>The following models of the Earth's magnetic field and its components (core, crust, lithospheric, magnetospheric, and ionospheric magnetic field) are available</p>
           <ul>
             <li style="list-style-type: circle;">
-              13th generation of the International Geomagnetic Reference Field (<a target="_blank" href="https://earth-planets-space.springeropen.com/articles/10.1186/s40623-020-01288-x">IGRF 13</a>) released in December 2019 by the International Association of Geomagnetism and Aeronomy
+              14th generation of the International Geomagnetic Reference Field (<a target="_blank" href="https://www.ncei.noaa.gov/products/international-geomagnetic-reference-field">IGRF-14</a>) released in November 2024 by the International Association of Geomagnetism and Aeronomy
             </li>
             <li style="list-style-type: circle;">
               The latest version of the CHAOS high resolution geomagnetic field model derived from Swarm, MSS-1, CSES, CryoSat-2, CHAMP, SAC-C, and Ørsted satellite magnetic data along with ground observatory data (<a target="_blank" href="https://spacecenter.dk/files/magnetic-models/CHAOS-8/">CHAOS-8</a>)

--- a/vires/setup.cfg
+++ b/vires/setup.cfg
@@ -27,5 +27,5 @@
 
 [bdist_rpm]
 release=1
-requires=EOxServer >= 0.4 python-matplotlib eoxmagmod >= 0.9.4
+requires=EOxServer >= 0.4 python-matplotlib eoxmagmod >= 0.13.0
 provides=VirES-Server

--- a/vires/vires/amps.py
+++ b/vires/vires/amps.py
@@ -58,7 +58,7 @@ def mjd2000_to_dt64ms(mjd2000):
             + DT64_2000
         )
     except ValueError as error:
-        raise ValueError("%s %r" % (error, mjd2000))
+        raise ValueError(f"{error} {mjd2000!r}") from None
 
 
 class AmpsMagneticFieldModel(GeomagneticModel):

--- a/vires/vires/magnetic_models/models.py
+++ b/vires/vires/magnetic_models/models.py
@@ -49,7 +49,6 @@ from eoxmagmod import (
 from eoxmagmod.time_util import decimal_year_to_mjd2000
 from eoxmagmod.magnetic_model.parser_shc import parse_shc_header
 from ..amps import AmpsMagneticFieldModel
-from ..util import cached_property
 from .files import (
     ModelFileWithLiteralSource,
     CachedModelFileWithSourceFile,
@@ -111,7 +110,7 @@ def _shc_validity_reader(file_, to_mjd2000):
     if hasattr(file_, 'read'):
         header = parse_shc_header(file_)
     else:
-        with open(file_) as file_in:
+        with open(file_, encoding="utf-8") as file_in:
             header = parse_shc_header(file_in)
     return (
         to_mjd2000(header["validity_start"]), to_mjd2000(header["validity_end"])

--- a/vires/vires/magnetic_models/models.py
+++ b/vires/vires/magnetic_models/models.py
@@ -30,7 +30,13 @@ from os.path import basename, splitext
 from logging import getLogger
 from numpy import inf
 from pyamps.model_utils import default_coeff_fn as AMPS
-from eoxmagmod.data import CHAOS_STATIC_LATEST, IGRF13, LCS1, MF7
+from eoxmagmod.data import (
+    CHAOS_STATIC_LATEST,
+    IGRF_LATEST,
+    IGRF_LATEST_SOURCE,
+    LCS1,
+    MF7,
+)
 from eoxmagmod import (
     load_model_shc,
     load_model_swarm_mma_2c_internal,
@@ -55,7 +61,6 @@ from .cache import ModelCache
 
 
 DIPOLE_MODEL = "IGRF"
-IGRF13_SOURCE = "SW_OPER_AUX_IGR_2__19000101T000000_20241231T235959_0103"
 CHAOS_STATIC_SOURCE = basename(CHAOS_STATIC_LATEST)
 LCS1_SOURCE = basename(LCS1)
 MF7_SOURCE = basename(MF7)
@@ -121,7 +126,7 @@ def mio_validity_reader(_):
 MODEL_FACTORIES = {
     "IGRF": ModelFactory(
         lambda file_: load_model_shc(file_, interpolate_in_decimal_years=True),
-        [ModelFileWithLiteralSource(IGRF13, IGRF13_SOURCE, shc_validity_reader)]
+        [ModelFileWithLiteralSource(IGRF_LATEST, IGRF_LATEST_SOURCE, shc_validity_reader)]
     ),
     "CHAOS-Static": ModelFactory(
         load_model_shc,

--- a/vires/vires/processes/util/time_series/custom_data.py
+++ b/vires/vires/processes/util/time_series/custom_data.py
@@ -64,7 +64,7 @@ class CustomDatasetTimeSeries(BaseProductTimeSeries):
             logger=self._LoggerAdapter(logger or getLogger(__name__), {
                 "username": user.username if user else "<anonymous-user>"
             }),
-            time_variable=params.TIME_VARIABLE,
+            time_variable=self.TIME_VARIABLE,
             time_tolerance=params.TIME_TOLERANCE,
             time_overlap=params.TIME_OVERLAP,
             time_gap_threshold=params.TIME_GAP_THRESHOLD,


### PR DESCRIPTION
Key features:
- update of the IGRF model (IGRF-13 -> IGRF-18)
- update of the CHAOS MLI part (CHAOS-7 -> CHAOS-8)
- various minor improvements

related to https://github.com/ESA-VirES/MagneticModel/pull/55