### PR TITLE
Hotfix: ULF, MIGRAS and TIRO products

### DIFF
--- a/eoxs_allauth/eoxs_allauth/templates/documents/changelog.html
+++ b/eoxs_allauth/eoxs_allauth/templates/documents/changelog.html
@@ -3,7 +3,44 @@
 {% block content %}
 <h1>Changelog</h1>
 <hr>
-<h3>
+<h3 id="3.15.2">
+    Release of Service v3.15.2 (2025-04-30)
+</h3>
+<p>
+    Features:
+</p>
+<ul>
+    <li><b>New Swarm L2 ULF and PC1 products</b><br>
+        The Swarm magnetic field ultra low frequency wave characterisation
+        <a target="_blank" href="https://swarmhandbook.earth.esa.int/catalogue/SW_ULFxMAG_2F">ULFxMAG_2F</a>
+        and
+        <a target="_blank" href="https://swarmhandbook.earth.esa.int/catalogue/SW_PC1xMAG_2F">PC1xMAG_2F</a>,
+        created by the Swarm DISC
+        <a href="https://earth.esa.int/eogateway/activities/swarm-ulf-ionosphere" target="_blank">ULF project</a>,
+        have been added to VirES and are accessible via the
+        <a href="https://viresclient.readthedocs.io/en/latest/available_parameters.html" target="_bank">VirES Python client</a>
+        and <a href="/hapi" target="_blank">HAPI</a>.
+    </li>
+    <li><b>New Swarm L2 NEGIX and TEGIX products</b><br>
+        The Swarm electron density (<a target="_blank" href="https://swarmhandbook.earth.esa.int/catalogue/SW_NIX_TMS_2F">NEGIX</a>)
+        and total electron content (<a target="_blank" href="https://swarmhandbook.earth.esa.int/catalogue/SW_TIX_TMS_2F">TEGIX</a>)
+        gradient ionosphere indices, created by the Swarm DISC
+        <a href="https://earth.esa.int/eogateway/activities/migras" target="_blank">MIGRAS project</a>,
+        have been added to VirES and are accessible via the
+        <a href="https://viresclient.readthedocs.io/en/latest/available_parameters.html" target="_bank">VirES Python client</a>
+        and <a href="/hapi" target="_blank">HAPI</a>.
+    </li>
+    <li><b>New CHAMP, GRACE, and GRACE-FO electron density and TEC products</b><br>
+        The CHAMP, GRACE, and GRACE-FO dual-spacecraft average electron density
+        total electron content (TEC) product, created by the Swarm DISC
+        <a href="https://earth.esa.int/eogateway/activities/tiro" target="_blank">TIRO project</a>,
+        have been added to VirES and are accessible via the
+        <a href="https://viresclient.readthedocs.io/en/latest/available_parameters.html" target="_bank">VirES Python client</a>
+        and <a href="/hapi" target="_blank">HAPI</a>.
+    </li>
+</ul>
+<hr>
+<h3 id="3.15.1">
     Release of Service v3.15.1 (2025-02-27)
 </h3>
 <p>
@@ -20,7 +57,7 @@
     </li>
 </ul>
 <hr>
-<h3>
+<h3 id="3.15.0">
     Release of Service v3.15.0 (2024-12-20)
 </h3>
 <p>

--- a/eoxs_allauth/eoxs_allauth/templates/documents/changelog.html
+++ b/eoxs_allauth/eoxs_allauth/templates/documents/changelog.html
@@ -4,7 +4,7 @@
 <h1>Changelog</h1>
 <hr>
 <h3 id="3.15.2">
-    Release of Service v3.15.2 (2025-04-30)
+    Release of Service v3.15.2 (2025-04-28)
 </h3>
 <p>
     Features:

--- a/eoxs_allauth/eoxs_allauth/templates/vires/workspace.html
+++ b/eoxs_allauth/eoxs_allauth/templates/vires/workspace.html
@@ -539,6 +539,19 @@
               of the Swarm, CHAMP, GOCE, GRACE, and GRACE-FO spacecrafts
               (<a href="https://swarmhandbook.earth.esa.int/catalogue/MM_CON_EPH_2_" target="_blank">MM_CON_EPH_2_</a>).
             </li>
+            <li style="list-style-type: circle;">
+              Dual-spacecraft average electron density products from the
+              GRACE (<a href="https://swarmhandbook.earth.esa.int/catalogue/GR_NE__KBR_2F" target="_blank">GR_NE__KBR_2F</a>),
+              GRACE-FO (<a href="https://swarmhandbook.earth.esa.int/catalogue/GF_NE__KBR_2F" target="_blank">GF_NE__KBR_2F</a>)
+              missions.
+            </li>
+            <li style="list-style-type: circle;">
+              Total electron content (TEC) products from the
+              CHAMP (<a href="https://swarmhandbook.earth.esa.int/catalogue/CH_TEC_TMS_2F" target="_blank">CH_TEC_TMS_2F</a>),
+              GRACE (<a href="https://swarmhandbook.earth.esa.int/catalogue/GR_TEC_KBR_2F" target="_blank">GR_TEC_KBR_2F</a>),
+              GRACE-FO (<a href="https://swarmhandbook.earth.esa.int/catalogue/GF_TEC_KBR_2F" target="_blank">GF_TEC_KBR_2F</a>)
+              missions.
+            </li>
           </ul>
           <p>
             These datasets can be accessed with the

--- a/eoxs_allauth/eoxs_allauth/templates/vires/workspace.html
+++ b/eoxs_allauth/eoxs_allauth/templates/vires/workspace.html
@@ -479,7 +479,8 @@
           <p>
             VirES also provides access to the
             <a href="https://earth.esa.int/eogateway/news/swarm-fast-data-ready-to-be-released" target="_blank">Swarm FAST L1B</a> and
-            <a href="https://earth.esa.int/eogateway/news/swarm-fast-field-aligned-currents-now-available-on-swarm-dissemination-server" target="_blank">L2</a>
+            L2 <a href="https://earth.esa.int/eogateway/news/swarm-fast-field-aligned-currents-now-available-on-swarm-dissemination-server" target="_blank">FAC</a>
+            and <a href="https://earth.esa.int/eogateway/news/swarm-level-2-fast-tec-data-now-available" target="_blank">TEC</a> products.
             The latests 6 months of the FAST
             <a target="_blank" href="https://swarmhandbook.earth.esa.int/catalogue/SW_MAGx_LR_1B">MAGx_LR_1B</a>,
             <a target="_blank" href="https://swarmhandbook.earth.esa.int/catalogue/SW_MAGx_HR_1B">MAGx_HR_1B</a>,

--- a/eoxs_allauth/eoxs_allauth/templates/vires/workspace.html
+++ b/eoxs_allauth/eoxs_allauth/templates/vires/workspace.html
@@ -480,6 +480,11 @@
               and <a target="_blank" href="https://swarmhandbook.earth.esa.int/catalogue/SW_PC1xMAG_2F">PC1xMAG_2F</a>)
               accessible via the <a target="_blank" href="https://viresclient.readthedocs.io/en/latest/available_parameters.html#collections">Python client</a>.
             </li>
+            <li style="list-style-type: circle;">
+              The Swarm electron density (<a target="_blank" href="https://swarmhandbook.earth.esa.int/catalogue/SW_NIX_TMS_2F">NEGIX</a>)
+              and total electron content (<a target="_blank" href="https://swarmhandbook.earth.esa.int/catalogue/SW_TIX_TMS_2F">TEGIX</a>)
+              products accessible via the <a target="_blank" href="https://viresclient.readthedocs.io/en/latest/available_parameters.html#collections">Python client</a>.
+            </li>
           </ul>
 
           <p>

--- a/eoxs_allauth/eoxs_allauth/templates/vires/workspace.html
+++ b/eoxs_allauth/eoxs_allauth/templates/vires/workspace.html
@@ -474,6 +474,12 @@
               and <a target="_blank" href="https://swarmhandbook.earth.esa.int/catalogue/SW_DNSxPOD_2_">SW_DNSxPOD_2_</a>)
               accessible via the <a target="_blank" href="https://viresclient.readthedocs.io/en/latest/available_parameters.html#collections">Python client</a>.
             </li>
+            <li style="list-style-type: circle;">
+              Magnetic field ultra low frequency wave characterisation products
+              (<a target="_blank" href="https://earth.esa.int/eogateway/activities/swarm-ulf-ionosphere">ULFxMAG_2F</a>
+              and <a target="_blank" href="https://earth.esa.int/eogateway/activities/swarm-ulf-ionosphere">PC1xMAG_2F</a>)
+              accessible via the <a target="_blank" href="https://viresclient.readthedocs.io/en/latest/available_parameters.html#collections">Python client</a>.
+            </li>
           </ul>
 
           <p>

--- a/eoxs_allauth/eoxs_allauth/templates/vires/workspace.html
+++ b/eoxs_allauth/eoxs_allauth/templates/vires/workspace.html
@@ -286,8 +286,8 @@
       </div>
 
         <p class="lead current-version text-center">
-          <strong>Version 3.15.1</strong> (<a href="/changelog">Changelog</a>)<br>
-          <em>February 2025</em>
+          <strong>Version 3.15.2</strong> (<a href="/changelog">Changelog</a>)<br>
+          <em>April 2025</em>
         </p>
 
         <p class="lead text-center">

--- a/eoxs_allauth/eoxs_allauth/templates/vires/workspace.html
+++ b/eoxs_allauth/eoxs_allauth/templates/vires/workspace.html
@@ -476,8 +476,8 @@
             </li>
             <li style="list-style-type: circle;">
               Magnetic field ultra low frequency wave characterisation products
-              (<a target="_blank" href="https://earth.esa.int/eogateway/activities/swarm-ulf-ionosphere">ULFxMAG_2F</a>
-              and <a target="_blank" href="https://earth.esa.int/eogateway/activities/swarm-ulf-ionosphere">PC1xMAG_2F</a>)
+              (<a target="_blank" href="https://swarmhandbook.earth.esa.int/catalogue/SW_ULFxMAG_2F">ULFxMAG_2F</a>
+              and <a target="_blank" href="https://swarmhandbook.earth.esa.int/catalogue/SW_PC1xMAG_2F">PC1xMAG_2F</a>)
               accessible via the <a target="_blank" href="https://viresclient.readthedocs.io/en/latest/available_parameters.html#collections">Python client</a>.
             </li>
           </ul>

--- a/vires/vires/data/product_collections.json
+++ b/vires/vires/data/product_collections.json
@@ -494,6 +494,64 @@
         "groupSamples": true
     },
     {
+        "name": "CH_OPER_TEC_TMS_2F",
+        "description": "CHAMP ionospheric total electron content",
+        "productType": "CH_TECxTMS_2F",
+        "nominalSampling": "PT10S",
+        "mission": "CHAMP",
+        "groupSamples": true
+    },
+    {
+        "name": "GR_OPER_TEC1TMS_2F",
+        "description": "GRACE 1 ionospheric total electron content",
+        "productType": "GR_TECxTMS_2F",
+        "nominalSampling": "PT10S",
+        "mission": "GRACE",
+        "spacecraft": "1",
+        "groupSamples": true
+    },
+    {
+        "name": "GR_OPER_TEC2TMS_2F",
+        "description": "GRACE 2 ionospheric total electron content",
+        "productType": "GR_TECxTMS_2F",
+        "nominalSampling": "PT10S",
+        "mission": "GRACE",
+        "spacecraft": "2",
+        "groupSamples": true
+    },
+    {
+        "name": "GR_OPER_NE__KBR_2F",
+        "description": "GRACE dual spacecraft average electron density",
+        "productType": "GR_NE__KBR_2F",
+        "nominalSampling": "PT5S",
+        "mission": "GRACE"
+    },
+    {
+        "name": "GF_OPER_TEC1TMS_2F",
+        "description": "GRACE-FO 1 ionospheric total electron content",
+        "productType": "GF_TECxTMS_2F",
+        "nominalSampling": "PT10S",
+        "mission": "GRACE-FO",
+        "spacecraft": "1",
+        "groupSamples": true
+    },
+    {
+        "name": "GF_OPER_TEC2TMS_2F",
+        "description": "GRACE-FO 2 ionospheric total electron content",
+        "productType": "GF_TECxTMS_2F",
+        "nominalSampling": "PT10S",
+        "mission": "GRACE-FO",
+        "spacecraft": "2",
+        "groupSamples": true
+    },
+    {
+        "name": "GF_OPER_NE__KBR_2F",
+        "description": "GRACE-FO dual spacecraft average electron density",
+        "productType": "GF_NE__KBR_2F",
+        "nominalSampling": "PT5S",
+        "mission": "GRACE-FO"
+    },
+    {
         "name": "SW_OPER_FACATMS_2F",
         "description": "Swarm A field-aligned and radial current densities using the single satellite measurements",
         "productType": "SW_FACxTMS_2F",

--- a/vires/vires/data/product_collections.json
+++ b/vires/vires/data/product_collections.json
@@ -805,6 +805,54 @@
         "extraSampled": true
     },
     {
+        "name": "SW_OPER_ULFAMAG_2F",
+        "description": "Swarm A Ultra Low Frequency (ULF) wave characterisation from low resolution vector magnetometer data",
+        "productType": "SW_ULFxMAG_2F",
+        "nominalSampling": "PT60S",
+        "mission": "Swarm",
+        "spacecraft": "A"
+    },
+    {
+        "name": "SW_OPER_ULFBMAG_2F",
+        "description": "Swarm B Ultra Low Frequency (ULF) wave characterisation from low resolution vector magnetometer data",
+        "productType": "SW_ULFxMAG_2F",
+        "nominalSampling": "PT60S",
+        "mission": "Swarm",
+        "spacecraft": "B"
+    },
+    {
+        "name": "SW_OPER_ULFCMAG_2F",
+        "description": "Swarm C Ultra Low Frequency (ULF) wave characterisation from low resolution vector magnetometer data",
+        "productType": "SW_ULFxMAG_2F",
+        "nominalSampling": "PT60S",
+        "mission": "Swarm",
+        "spacecraft": "C"
+    },
+    {
+        "name": "SW_OPER_PC1AMAG_2F",
+        "description": "Swarm A Pc1 wave characterisation from high resolution vector magnetometer data",
+        "productType": "SW_PC1xMAG_2F",
+        "nominalSampling": "PT15S",
+        "mission": "Swarm",
+        "spacecraft": "A"
+    },
+    {
+        "name": "SW_OPER_PC1BMAG_2F",
+        "description": "Swarm B Pc1 wave characterisation from high resolution vector magnetometer data",
+        "productType": "SW_PC1xMAG_2F",
+        "nominalSampling": "PT15S",
+        "mission": "Swarm",
+        "spacecraft": "B"
+    },
+    {
+        "name": "SW_OPER_PC1CMAG_2F",
+        "description": "Swarm C Pc1 wave characterisation from high resolution vector magnetometer data",
+        "productType": "SW_PC1xMAG_2F",
+        "nominalSampling": "PT15S",
+        "mission": "Swarm",
+        "spacecraft": "C"
+    },
+    {
         "name": "SW_OPER_AUX_IMF_2_",
         "productType": "SW_AUX_IMF_2_",
         "nominalSampling": "PT3600S",

--- a/vires/vires/data/product_collections.json
+++ b/vires/vires/data/product_collections.json
@@ -1300,6 +1300,7 @@
     {
         "name": "MM_OPER_CON_EPH_2_",
         "productType": "MM_CON_EPH_2_",
+        "mission": "multi-mission",
         "nominalSampling": {
             "crossover": "PT20M",
             "plane_alignment": "P1D"

--- a/vires/vires/data/product_types.json
+++ b/vires/vires/data/product_types.json
@@ -4185,7 +4185,7 @@
     {
         "name": "SW_ULFxMAG_2F",
         "description": "Swarm Ultra Low Frequency (ULF) wave characterisation from low resolution vector magnetometer data",
-        "resourceUrl": "https://earth.esa.int/eogateway/activities/swarm-ulf-ionosphere",
+        "resourceUrl": "https://swarmhandbook.earth.esa.int/catalogue/SW_ULFxMAG_2F",
         "dataTerms": "This dataset is provided by the European Space Agency and it is subject to terms condition described in https://vires.services/data_terms.",
         "_order": 40,
         "fileType": "CDF-with-timespan-attribute",
@@ -4765,7 +4765,7 @@
     {
         "name": "SW_PC1xMAG_2F",
         "description": "Swarm Pc1 wave characterisation from high resolution vector magnetometer data",
-        "resourceUrl": "https://earth.esa.int/eogateway/activities/swarm-ulf-ionosphere",
+        "resourceUrl": "https://swarmhandbook.earth.esa.int/catalogue/SW_PC1xMAG_2F",
         "dataTerms": "This dataset is provided by the European Space Agency and it is subject to terms condition described in https://vires.services/data_terms.",
         "_order": 41,
         "fileType": "CDF-with-timespan-attribute",

--- a/vires/vires/data/product_types.json
+++ b/vires/vires/data/product_types.json
@@ -1451,24 +1451,20 @@
                     "dataType": "float64",
                     "attributes": {
                         "DESCRIPTION": "Geographic radius",
-                        "UNITS": "km"
+                        "UNITS": "m"
                     }
                 },
                 "GPS_Position": {
                     "dataType": "float64",
-                    "dimension": [
-                        3
-                    ],
+                    "dimension": [3],
                     "attributes": {
                         "DESCRIPTION": "X-,Y-,Z-coordinates (WGS84) of the GPS satellite",
-                        "UNITS": "km"
+                        "UNITS": "m"
                     }
                 },
                 "LEO_Position": {
                     "dataType": "float64",
-                    "dimension": [
-                        3
-                    ],
+                    "dimension": [3],
                     "attributes": {
                         "DESCRIPTION": "X-,Y-,Z-coordinates (WGS84) of the LEO satellite",
                         "UNITS": "m"

--- a/vires/vires/data/product_types.json
+++ b/vires/vires/data/product_types.json
@@ -3142,6 +3142,1644 @@
         }
     },
     {
+        "name": "SW_ULFxMAG_2F",
+        "description": "Swarm Ultra Low Frequency (ULF) wave characterisation from low resolution vector magnetometer data",
+        "resourceUrl": "https://earth.esa.int/eogateway/activities/swarm-ulf-ionosphere",
+        "dataTerms": "This dataset is provided by the European Space Agency and it is subject to terms condition described in https://vires.services/data_terms.",
+        "_order": 40,
+        "fileType": "CDF-with-timespan-attribute",
+        "defaultDataset": "__main__",
+        "datasets": {
+            "__main__": {
+                "Timestamp": {
+                    "essentialVariable": true,
+                    "primaryTimestamp": true,
+                    "dataType": "timestamp",
+                    "dataSubtype": "CDF_EPOCH",
+                    "attributes": {
+                        "DESCRIPTION": "Time of observation, UTC",
+                        "UNITS": "-",
+                        "FORMAT": " "
+                    }
+                },
+                "Latitude": {
+                    "essentialVariable": true,
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Geocentric latitude",
+                        "UNITS": "deg",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "Longitude": {
+                    "essentialVariable": true,
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Geocentric longitude",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Radius": {
+                    "essentialVariable": true,
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Geocentric radius",
+                        "UNITS": "m",
+                        "FORMAT": "F8.0"
+                    }
+                },
+                "Latitude_QD": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Quasi-dipole latitude",
+                        "UNITS": "deg",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "Longitude_QD": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Quasi-dipole longitude",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "UT": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Universal Time",
+                        "UNITS": "hr",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "MLT_QD": {
+                    "source": "MLT",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Magnetic local time",
+                        "UNITS": "hr",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "SZA": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Solar zenith angle",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Frequency_dominant": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Dominant frequency",
+                        "UNITS": "mhz",
+                        "FORMAT": "F6.1"
+                    }
+                },
+                "Halfwidth": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Spectral width of the peak",
+                        "UNITS": "mhz",
+                        "FORMAT": "F6.1"
+                    }
+                },
+                "Power": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Peak power",
+                        "UNITS": "log(nT^2)",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Prominence": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Peak prominence",
+                        "UNITS": "-",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Pc2_act": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Rms of the fluctuations in the Pc2 band",
+                        "UNITS": "pT",
+                        "FORMAT": "F7.0"
+                    }
+                },
+                "Pc3_act": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Rms of the fluctuations in the Pc3 band",
+                        "UNITS": "pT",
+                        "FORMAT": "F7.0"
+                    }
+                },
+                "Pc4_act": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Rms of the fluctuations in the Pc4 band",
+                        "UNITS": "pT",
+                        "FORMAT": "F7.0"
+                    }
+                },
+                "Pi2_act": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Rms of the fluctuations in the Pi2 band",
+                        "UNITS": "pT",
+                        "FORMAT": "F7.0"
+                    }
+                },
+                "Flag_Pc2": {
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Flag indicating the presence of Pc2 waves",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "Flag_Pc3": {
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Flag indicating the presence of Pc3 waves",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "Flag_Pc4": {
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Flag indicating the presence of Pc4 waves",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "Flag_Pi2": {
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Flag indicating the presence of Pi2 waves",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "Flag_EPB": {
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Flag indicating significant EPB activity",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "Flag_FAC": {
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Flag indicating intense FAC activity",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                }
+            },
+            "event": {
+                "Timestamp": {
+                    "essentialVariable": true,
+                    "primaryTimestamp": true,
+                    "source": "Timestamp_e",
+                    "dataType": "timestamp",
+                    "dataSubtype": "CDF_EPOCH",
+                    "attributes": {
+                        "DESCRIPTION": "Time of observation ffor ID event points, UTC",
+                        "UNITS": "-",
+                        "FORMAT": " "
+                    }
+                },
+                "Latitude": {
+                    "essentialVariable": true,
+                    "source": "Latitude_e",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Geocentric latitude for ID event points",
+                        "UNITS": "deg",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "Longitude": {
+                    "essentialVariable": true,
+                    "source": "Longitude_e",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Geocentric longitude for ID event points",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Radius": {
+                    "essentialVariable": true,
+                    "source": "Radius_e",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Geocentric radius for ID event points",
+                        "UNITS": "m",
+                        "FORMAT": "F8.0"
+                    }
+                },
+                "Latitude_QD": {
+                    "source": "Latitude_QD_e",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Quasi-dipole latitude for ID event points",
+                        "UNITS": "deg",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "Longitude_QD": {
+                    "source": "Longitude_QD_e",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Quasi-dipole longitude for ID event points",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "MLT_QD": {
+                    "source": "MLT_e",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Magnetic Local Time for ID event points",
+                        "UNITS": "hr",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "SZA": {
+                    "source": "SZA_e",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Solar zenith angle for ID event points",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "ID": {
+                    "source": "ID_e",
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Event identifier",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "ORB": {
+                    "source": "ORB_e",
+                    "dataType": "uint32",
+                    "attributes": {
+                        "DESCRIPTION": "Orbit number for ID event points",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "DIR": {
+                    "source": "DIR_e",
+                    "dataType": "int8",
+                    "attributes": {
+                        "DESCRIPTION": "Flight direction for ID event points",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "Frequency": {
+                    "source": "Frequency_e",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous frequency for ID event points",
+                        "UNITS": "mHz",
+                        "FORMAT": "F7.0"
+                    }
+                },
+                "Halfwidth": {
+                    "source": "Halfwidth_e",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous spectral peak half width for ID event points",
+                        "UNITS": "mHz",
+                        "FORMAT": "F6.1"
+                    }
+                },
+                "Power": {
+                    "source": "Power_e",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous  power for ID event points",
+                        "UNITS": "log(nT^2)",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Prominence": {
+                    "source": "Prominence_e",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous prominence for ID event points",
+                        "UNITS": "-",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "EPB": {
+                    "source": "EPB_e",
+                    "dataType": "int8",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous plasma bubble indicator for ID event points",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "FAC": {
+                    "source": "FAC_e",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous rms FAC intensity for ID event points",
+                        "UNITS": "uA/m^2",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "Flag_B": {
+                    "source": "Flag_B_e",
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous Flag B from MAGx_LR L1b product",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "Quality": {
+                    "source": "Quality_e",
+                    "dataType": "int8",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous Quality for ID event points",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                }
+            },
+            "event_mean": {
+                "Timestamp": {
+                    "essentialVariable": true,
+                    "primaryTimestamp": true,
+                    "source": "Timestamp_m",
+                    "dataType": "timestamp",
+                    "dataSubtype": "CDF_EPOCH",
+                    "attributes": {
+                        "DESCRIPTION": "Event mean time of observation, UTC",
+                        "UNITS": "-",
+                        "FORMAT": " "
+                    }
+                },
+                "Latitude": {
+                    "essentialVariable": true,
+                    "source": "Latitude_m",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Event mean position in ITRF - Geocentric latitude",
+                        "UNITS": "deg",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "Longitude": {
+                    "essentialVariable": true,
+                    "source": "Longitude_m",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Event mean position in ITRF - Geocentric longitude",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Radius": {
+                    "essentialVariable": true,
+                    "source": "Radius_m",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Event mean position in ITRF - Geocentric radius",
+                        "UNITS": "m",
+                        "FORMAT": "F8.0"
+                    }
+                },
+                "Latitude_QD": {
+                    "source": "Latitude_QD_m",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Event mean quasi-dipole latitude",
+                        "UNITS": "deg",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "Longitude_QD": {
+                    "source": "Longitude_QD_m",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Event mean quasi-dipole longitude",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "MLT_QD": {
+                    "source": "MLT_m",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Event mean magnetic local time",
+                        "UNITS": "hr",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "SZA": {
+                    "source": "SZA_m",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Event mean solar zenith angle",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "ID": {
+                    "source": "ID_m",
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Event identifier for event mean properties",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "ORB": {
+                    "source": "ORB_m",
+                    "dataType": "uint32",
+                    "attributes": {
+                        "DESCRIPTION": "Orbit number for event mean properties",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "DIR": {
+                    "source": "DIR_m",
+                    "dataType": "int8",
+                    "attributes": {
+                        "DESCRIPTION": "Flight direction for event mean properties",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "Duration": {
+                    "source": "Duration_m",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Event duration",
+                        "UNITS": "s",
+                        "FORMAT": "F7.0"
+                    }
+                },
+                "Frequency": {
+                    "source": "Frequency_m",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Event mean ULF frequency",
+                        "UNITS": "mHz",
+                        "FORMAT": "F7.0"
+                    }
+                },
+                "Freq_std": {
+                    "source": "Freq_std_m",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Standard deviation of the spectral peak",
+                        "UNITS": "mHz",
+                        "FORMAT": "F6.1"
+                    }
+                },
+                "Halfwidth": {
+                    "source": "Halfwidth_m",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Event mean spectral peak half width",
+                        "UNITS": "mHz",
+                        "FORMAT": "F6.1"
+                    }
+                },
+                "Power": {
+                    "source": "Power_m",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Event mean power",
+                        "UNITS": "log(nT^2)",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Prominence": {
+                    "source": "Prominence_m",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Event mean prominence",
+                        "UNITS": "-",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "EPB": {
+                    "source": "EPB_m",
+                    "dataType": "int8",
+                    "attributes": {
+                        "DESCRIPTION": "Event peak plasma bubble indicator",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "FAC": {
+                    "source": "FAC_m",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Event peak rms FAC intensity",
+                        "UNITS": "uA/m^2",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "Flag_B": {
+                    "source": "Flag_B_m",
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Event maximum Flag B from MAGx_LR L1b product",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "Quality": {
+                    "source": "Quality_m",
+                    "dataType": "int8",
+                    "attributes": {
+                        "DESCRIPTION": "Overall event quality",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                }
+            }
+        }
+    },
+    {
+        "name": "SW_PC1xMAG_2F",
+        "description": "Swarm Pc1 wave characterisation from high resolution vector magnetometer data",
+        "resourceUrl": "https://earth.esa.int/eogateway/activities/swarm-ulf-ionosphere",
+        "dataTerms": "This dataset is provided by the European Space Agency and it is subject to terms condition described in https://vires.services/data_terms.",
+        "_order": 41,
+        "fileType": "CDF-with-timespan-attribute",
+        "datasets": {
+            "Bp_event": {
+                "ID": {
+                    "essentialVariable": true,
+                    "source": "ID_Bp",
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Bp component event identifier",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "Timestamp": {
+                    "essentialVariable": true,
+                    "primaryTimestamp": true,
+                    "source": "Timestamp_Bp",
+                    "dataType": "timestamp",
+                    "dataSubtype": "CDF_EPOCH",
+                    "attributes": {
+                        "DESCRIPTION": "Time of observation for the Bp component ID event, UTC",
+                        "UNITS": "-",
+                        "FORMAT": " "
+                    }
+                },
+                "Latitude": {
+                    "essentialVariable": true,
+                    "source": "Latitude_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Geocentric latitude for the Bp component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "Longitude": {
+                    "essentialVariable": true,
+                    "source": "Longitude_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Geocentric longitude for the Bp component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Radius": {
+                    "essentialVariable": true,
+                    "source": "Radius_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Geocentric radius (from the Earth centre) for the Bp component ID event",
+                        "UNITS": "m",
+                        "FORMAT": "F8.0"
+                    }
+                },
+                "Latitude_QD": {
+                    "source": "Latitude_QD_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "QD latitude for the Bp component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "Longitude_QD": {
+                    "source": "Longitude_QD_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "QD longitude for the Bp component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "MLT_QD": {
+                    "source": "MLT_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Magnetic Local Time for the Bp component ID event",
+                        "UNITS": "hr",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "SZA": {
+                    "source": "SZA_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Solar zenith angle for the Bp component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "ORB": {
+                    "source": "ORB_Bp",
+                    "dataType": "uint32",
+                    "attributes": {
+                        "DESCRIPTION": "Orbit number for the Bp component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "DIR": {
+                    "source": "DIR_Bp",
+                    "dataType": "int8",
+                    "attributes": {
+                        "DESCRIPTION": "Flight direction for the Bp component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "Frequency": {
+                    "source": "Frequency_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous frequency for the Bp component ID event",
+                        "UNITS": "Hz",
+                        "FORMAT": "F7.0"
+                    }
+                },
+                "Halfwidth": {
+                    "source": "Halfwidth_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous spectral peak half width for the Bp component ID event",
+                        "UNITS": "Hz",
+                        "FORMAT": "F6.1"
+                    }
+                },
+                "Power": {
+                    "source": "Power_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous  power for the Bp component ID event",
+                        "UNITS": "nT^2/Hz",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Prominence": {
+                    "source": "Prominence_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous prominence for the Bp component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Quality_B": {
+                    "source": "Quality_B_Bp",
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous MAGxHR quality for the Bp component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "Quality_p": {
+                    "source": "Quality_p_Bp",
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous peak quality for the Bp component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "Quality_n": {
+                    "source": "Quality_n_Bp",
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous noise quality for the Bp component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                }
+            },
+            "Bp_event_mean": {
+                "Timestamp": {
+                    "essentialVariable": true,
+                    "primaryTimestamp": true,
+                    "source": "Timestamp_m_Bp",
+                    "dataType": "timestamp",
+                    "dataSubtype": "CDF_EPOCH",
+                    "attributes": {
+                        "DESCRIPTION": "Mean time of observation for the Bp component ID event, UTC",
+                        "UNITS": "-",
+                        "FORMAT": " "
+                    }
+                },
+                "Latitude": {
+                    "essentialVariable": true,
+                    "source": "Latitude_m_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean position in ITRF - Geocentric latitude for the Bp component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "Longitude": {
+                    "essentialVariable": true,
+                    "source": "Longitude_m_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean position in ITRF - Geocentric longitude for the Bp component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Radius": {
+                    "essentialVariable": true,
+                    "source": "Radius_m_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean position in ITRF - Geocentric radius (from the Earth centre) for the Bp component ID event",
+                        "UNITS": "m",
+                        "FORMAT": "F8.0"
+                    }
+                },
+                "Latitude_QD": {
+                    "source": "Latitude_QD_m_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean QD latitude for the Bp component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "Longitude_QD": {
+                    "source": "Longitude_QD_m_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean QD longitude for the Bp component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "MLT_QD": {
+                    "source": "MLT_m_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean Magnetic Local Time for the Bp component ID event",
+                        "UNITS": "hr",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "SZA": {
+                    "source": "SZA_m_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean Solar zenith angle for the Bp component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "ID": {
+                    "source": "ID_m_Bp",
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Bp component event identifier for event mean properties",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "ORB": {
+                    "source": "ORB_m_Bp",
+                    "dataType": "uint32",
+                    "attributes": {
+                        "DESCRIPTION": "Orbit number for the Bp component ID event (mean properties)",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "DIR": {
+                    "source": "DIR_m_Bp",
+                    "dataType": "int8",
+                    "attributes": {
+                        "DESCRIPTION": "Flight direction for the Bp component ID event (mean properties)",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "Duration": {
+                    "source": "Duration_m_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Duration of the Bp component ID event",
+                        "UNITS": "min",
+                        "FORMAT": "F7.0"
+                    }
+                },
+                "Frequency": {
+                    "source": "Frequency_m_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean frequency for the Bp component ID event",
+                        "UNITS": "Hz",
+                        "FORMAT": "F7.0"
+                    }
+                },
+                "Freq_std": {
+                    "source": "Freq_std_m_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Standard deviation of the spectral peak frequencies for the Bp component ID event",
+                        "UNITS": "Hz",
+                        "FORMAT": "F6.1"
+                    }
+                },
+                "Halfwidth": {
+                    "source": "Halfwidth_m_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean spectral peak half width for the Bp component ID event",
+                        "UNITS": "Hz",
+                        "FORMAT": "F6.1"
+                    }
+                },
+                "Power": {
+                    "source": "Power_m_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean power for the Bp component ID event",
+                        "UNITS": "nT^2/Hz",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Prominence": {
+                    "source": "Prominence_m_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean prominence for the Bp component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "ROFC": {
+                    "source": "ROFC_m_Bp",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Rate of frequency change for the Bp component ID event",
+                        "UNITS": "Hz/s",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Quality": {
+                    "source": "Quality_m_Bp",
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Overall quality for the Bp component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                }
+            },
+            "Br_event": {
+                "Timestamp": {
+                    "essentialVariable": true,
+                    "primaryTimestamp": true,
+                    "source": "Timestamp_Br",
+                    "dataType": "timestamp",
+                    "dataSubtype": "CDF_EPOCH",
+                    "attributes": {
+                        "DESCRIPTION": "Time of observation for the Br component ID event, UTC",
+                        "UNITS": "-",
+                        "FORMAT": " "
+                    }
+                },
+                "Latitude": {
+                    "essentialVariable": true,
+                    "source": "Latitude_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Geocentric latitude for the Br component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "Longitude": {
+                    "essentialVariable": true,
+                    "source": "Longitude_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Geocentric longitude for the Br component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Radius": {
+                    "essentialVariable": true,
+                    "source": "Radius_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Geocentric radius (from the Earth centre) for the Br component ID event",
+                        "UNITS": "m",
+                        "FORMAT": "F8.0"
+                    }
+                },
+                "Latitude_QD": {
+                    "source": "Latitude_QD_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "QD latitude for the Br component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "Longitude_QD": {
+                    "source": "Longitude_QD_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "QD longitude for the Br component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "MLT_QD": {
+                    "source": "MLT_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Magnetic Local Time for the Br component ID event",
+                        "UNITS": "hr",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "SZA": {
+                    "source": "SZA_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Solar zenith angle for the Br component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "ID": {
+                    "source": "ID_Br",
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Br component event identifier",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "ORB": {
+                    "source": "ORB_Br",
+                    "dataType": "uint32",
+                    "attributes": {
+                        "DESCRIPTION": "Orbit number for the Br component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "DIR": {
+                    "source": "DIR_Br",
+                    "dataType": "int8",
+                    "attributes": {
+                        "DESCRIPTION": "Flight direction for the Br component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "Frequency": {
+                    "source": "Frequency_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous frequency for the Br component ID event",
+                        "UNITS": "Hz",
+                        "FORMAT": "F7.0"
+                    }
+                },
+                "Halfwidth": {
+                    "source": "Halfwidth_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous spectral peak half width for the Br component ID event",
+                        "UNITS": "Hz",
+                        "FORMAT": "F6.1"
+                    }
+                },
+                "Power": {
+                    "source": "Power_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous  power for the Br component ID event",
+                        "UNITS": "nT^2/Hz",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Prominence": {
+                    "source": "Prominence_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous prominence for the Br component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Quality_B": {
+                    "source": "Quality_B_Br",
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous MAGxHR quality for the Br component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "Quality_p": {
+                    "source": "Quality_p_Br",
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous peak quality for the Br component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "Quality_n": {
+                    "source": "Quality_n_Br",
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous noise quality for the Br component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                }
+            },
+            "Br_event_mean": {
+                "Timestamp": {
+                    "essentialVariable": true,
+                    "primaryTimestamp": true,
+                    "source": "Timestamp_m_Br",
+                    "dataType": "timestamp",
+                    "dataSubtype": "CDF_EPOCH",
+                    "attributes": {
+                        "DESCRIPTION": "Mean time of observation for the Br component ID event, UTC",
+                        "UNITS": "-",
+                        "FORMAT": " "
+                    }
+                },
+                "Latitude": {
+                    "essentialVariable": true,
+                    "source": "Latitude_m_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean position in ITRF - Geocentric latitude for the Br component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "Longitude": {
+                    "essentialVariable": true,
+                    "source": "Longitude_m_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean position in ITRF - Geocentric longitude for the Br component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Radius": {
+                    "essentialVariable": true,
+                    "source": "Radius_m_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean position in ITRF - Geocentric radius (from the Earth centre) for the Br component ID event",
+                        "UNITS": "m",
+                        "FORMAT": "F8.0"
+                    }
+                },
+                "Latitude_QD": {
+                    "source": "Latitude_QD_m_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean QD latitude for the Br component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "Longitude_QD": {
+                    "source": "Longitude_QD_m_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean QD longitude for the Br component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "MLT_QD": {
+                    "source": "MLT_m_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean Magnetic Local Time for the Br component ID event",
+                        "UNITS": "hr",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "SZA": {
+                    "source": "SZA_m_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean Solar zenith angle for the Br component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "ID": {
+                    "source": "ID_m_Br",
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Br component event identifier for event mean properties",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "ORB": {
+                    "source": "ORB_m_Br",
+                    "dataType": "uint32",
+                    "attributes": {
+                        "DESCRIPTION": "Orbit number for the Br component ID event (mean properties)",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "DIR": {
+                    "source": "DIR_m_Br",
+                    "dataType": "int8",
+                    "attributes": {
+                        "DESCRIPTION": "Flight direction for the Br component ID event (mean properties)",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "Duration": {
+                    "source": "Duration_m_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Duration of the Br component ID event",
+                        "UNITS": "min",
+                        "FORMAT": "F7.0"
+                    }
+                },
+                "Frequency": {
+                    "source": "Frequency_m_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean frequency for the Br component ID event",
+                        "UNITS": "Hz",
+                        "FORMAT": "F7.0"
+                    }
+                },
+                "Freq_std": {
+                    "source": "Freq_std_m_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Standard deviation of the spectral peak frequencies for the Br component ID event",
+                        "UNITS": "Hz",
+                        "FORMAT": "F6.1"
+                    }
+                },
+                "Halfwidth": {
+                    "source": "Halfwidth_m_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean spectral peak half width for the Br component ID event",
+                        "UNITS": "Hz",
+                        "FORMAT": "F6.1"
+                    }
+                },
+                "Power": {
+                    "source": "Power_m_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean power for the Br component ID event",
+                        "UNITS": "nT^2/Hz",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Prominence": {
+                    "source": "Prominence_m_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean prominence for the Br component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "ROFC": {
+                    "source": "ROFC_m_Br",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Rate of frequency change for the Br component ID event",
+                        "UNITS": "Hz/s",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Quality": {
+                    "source": "Quality_m_Br",
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Overall quality for the Br component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                }
+            },
+            "Ba_event": {
+                "Timestamp": {
+                    "essentialVariable": true,
+                    "primaryTimestamp": true,
+                    "source": "Timestamp_Ba",
+                    "dataType": "timestamp",
+                    "dataSubtype": "CDF_EPOCH",
+                    "attributes": {
+                        "DESCRIPTION": "Time of observation for the Ba component ID event, UTC",
+                        "UNITS": "-",
+                        "FORMAT": " "
+                    }
+                },
+                "Latitude": {
+                    "essentialVariable": true,
+                    "source": "Latitude_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Geocentric latitude for the Ba component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "Longitude": {
+                    "essentialVariable": true,
+                    "source": "Longitude_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Geocentric longitude for the Ba component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Radius": {
+                    "essentialVariable": true,
+                    "source": "Radius_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Geocentric radius (from the Earth centre) for the Ba component ID event",
+                        "UNITS": "m",
+                        "FORMAT": "F8.0"
+                    }
+                },
+                "Latitude_QD": {
+                    "source": "Latitude_QD_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "QD latitude for the Ba component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "Longitude_QD": {
+                    "source": "Longitude_QD_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "QD longitude for the Ba component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "MLT_QD": {
+                    "source": "MLT_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Magnetic Local Time for the Ba component ID event",
+                        "UNITS": "hr",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "SZA": {
+                    "source": "SZA_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Solar zenith angle for the Ba component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "ID": {
+                    "source": "ID_Ba",
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Ba component event identifier",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "ORB": {
+                    "source": "ORB_Ba",
+                    "dataType": "uint32",
+                    "attributes": {
+                        "DESCRIPTION": "Orbit number for the Ba component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "DIR": {
+                    "source": "DIR_Ba",
+                    "dataType": "int8",
+                    "attributes": {
+                        "DESCRIPTION": "Flight direction for the Ba component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "Frequency": {
+                    "source": "Frequency_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous frequency for the Ba component ID event",
+                        "UNITS": "Hz",
+                        "FORMAT": "F7.0"
+                    }
+                },
+                "Halfwidth": {
+                    "source": "Halfwidth_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous spectral peak half width for the Ba component ID event",
+                        "UNITS": "Hz",
+                        "FORMAT": "F6.1"
+                    }
+                },
+                "Power": {
+                    "source": "Power_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous  power for the Ba component ID event",
+                        "UNITS": "nT^2/Hz",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Prominence": {
+                    "source": "Prominence_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous prominence for the Ba component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Quality_B": {
+                    "source": "Quality_B_Ba",
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous MAGxHR quality for the Ba component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "Quality_p": {
+                    "source": "Quality_p_Ba",
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous peak quality for the Ba component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "Quality_n": {
+                    "source": "Quality_n_Ba",
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Instantaneous noise quality for the Ba component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                }
+            },
+            "Ba_event_mean": {
+                "Timestamp": {
+                    "essentialVariable": true,
+                    "primaryTimestamp": true,
+                    "source": "Timestamp_m_Ba",
+                    "dataType": "timestamp",
+                    "dataSubtype": "CDF_EPOCH",
+                    "attributes": {
+                        "DESCRIPTION": "Mean time of observation for the Ba component ID event, UTC",
+                        "UNITS": "-",
+                        "FORMAT": " "
+                    }
+                },
+                "Latitude": {
+                    "essentialVariable": true,
+                    "source": "Latitude_m_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean position in ITRF - Geocentric latitude for the Ba component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "Longitude": {
+                    "essentialVariable": true,
+                    "source": "Longitude_m_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean position in ITRF - Geocentric longitude for the Ba component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Radius": {
+                    "essentialVariable": true,
+                    "source": "Radius_m_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean position in ITRF - Geocentric radius (from the Earth centre) for the Ba component ID event",
+                        "UNITS": "m",
+                        "FORMAT": "F8.0"
+                    }
+                },
+                "Latitude_QD": {
+                    "source": "Latitude_QD_m_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean QD latitude for the Ba component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "Longitude_QD": {
+                    "source": "Longitude_QD_m_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean QD longitude for the Ba component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "MLT_QD": {
+                    "source": "MLT_m_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean Magnetic Local Time for the Ba component ID event",
+                        "UNITS": "hr",
+                        "FORMAT": "F6.2"
+                    }
+                },
+                "SZA": {
+                    "source": "SZA_m_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean Solar zenith angle for the Ba component ID event",
+                        "UNITS": "deg",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "ID": {
+                    "source": "ID_m_Ba",
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Ba component event identifier for event mean properties",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "ORB": {
+                    "source": "ORB_m_Ba",
+                    "dataType": "uint32",
+                    "attributes": {
+                        "DESCRIPTION": "Orbit number for the Ba component ID event (mean properties)",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "DIR": {
+                    "source": "DIR_m_Ba",
+                    "dataType": "int8",
+                    "attributes": {
+                        "DESCRIPTION": "Flight direction for the Ba component ID event (mean properties)",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                },
+                "Duration": {
+                    "source": "Duration_m_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Duration of the Ba component ID event",
+                        "UNITS": "min",
+                        "FORMAT": "F7.0"
+                    }
+                },
+                "Frequency": {
+                    "source": "Frequency_m_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean frequency for the Ba component ID event",
+                        "UNITS": "Hz",
+                        "FORMAT": "F7.0"
+                    }
+                },
+                "Freq_std": {
+                    "source": "Freq_std_m_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Standard deviation of the spectral peak frequencies for the Ba component ID event",
+                        "UNITS": "Hz",
+                        "FORMAT": "F6.1"
+                    }
+                },
+                "Halfwidth": {
+                    "source": "Halfwidth_m_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean spectral peak half width for the Ba component ID event",
+                        "UNITS": "Hz",
+                        "FORMAT": "F6.1"
+                    }
+                },
+                "Power": {
+                    "source": "Power_m_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean power for the Ba component ID event",
+                        "UNITS": "nT^2/Hz",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Prominence": {
+                    "source": "Prominence_m_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean prominence for the Ba component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "ROFC": {
+                    "source": "ROFC_m_Ba",
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Rate of frequency change for the Ba component ID event",
+                        "UNITS": "Hz/s",
+                        "FORMAT": "F7.2"
+                    }
+                },
+                "Quality": {
+                    "source": "Quality_m_Ba",
+                    "dataType": "uint8",
+                    "attributes": {
+                        "DESCRIPTION": "Overall quality for the Ba component ID event",
+                        "UNITS": "-",
+                        "FORMAT": "D1"
+                    }
+                }
+            }
+        }
+    },
+    {
         "name": "OMNI_HR_1min",
         "fileType": "CDF-generic",
         "defaultDataset": "OMNI_HR_1min",

--- a/vires/vires/data/product_types.json
+++ b/vires/vires/data/product_types.json
@@ -1572,11 +1572,660 @@
         }
     },
     {
+        "name": "CH_TECxTMS_2F",
+        "description": "CHAMP ionospheric total electron content",
+        "resourceUrl": "https://swarmhandbook.earth.esa.int/catalogue/CH_TEC_TMS_2F",
+        "dataTerms": "This dataset is provided by the European Space Agency and it is subject to terms condition described in https://vires.services/data_terms.",
+        "_order": 27,
+        "fileType": "CDF-generic",
+        "defaultDataset": "TEC_TMS",
+        "datasets": {
+            "TEC_TMS": {
+                "Timestamp": {
+                    "essentialVariable": true,
+                    "primaryTimestamp": true,
+                    "dataType": "timestamp",
+                    "dataSubtype": "CDF_EPOCH",
+                    "attributes": {
+                        "DESCRIPTION": "Time of observation, UTC",
+                        "UNITS": "-"
+                    }
+                },
+                "Latitude": {
+                    "essentialVariable": true,
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Latitude",
+                        "UNITS": "deg"
+                    }
+                },
+                "Longitude": {
+                    "essentialVariable": true,
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Longitude",
+                        "UNITS": "deg"
+                    }
+                },
+                "Radius": {
+                    "essentialVariable": true,
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Radius",
+                        "UNITS": "m"
+                    }
+                },
+                "GPS_Position": {
+                    "dataType": "float64",
+                    "dimension": [3],
+                    "attributes": {
+                        "DESCRIPTION": "X-,Y-,Z-coordinates of the GPS satellite",
+                        "UNITS": "m"
+                    }
+                },
+                "LEO_Position": {
+                    "dataType": "float64",
+                    "dimension": [3],
+                    "attributes": {
+                        "DESCRIPTION": "X-,Y-,Z-coordinates of the LEO satellite",
+                        "UNITS": "m"
+                    }
+                },
+                "PRN": {
+                    "dataType": "uint16",
+                    "attributes": {
+                        "DESCRIPTION": "Pseudorandom noise (PRN) code of GPS satellite",
+                        "UNITS": "-"
+                    }
+                },
+                "L1": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "GPS L1C (LA in RINEX v.2.10) carrier phase observation",
+                        "UNITS": "m"
+                    }
+                },
+                "L2": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "GPS L2W (L2 in RINEX v.2.10) carrier phase observation",
+                        "UNITS": "m"
+                    }
+                },
+                "P1": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "GPS C1W (P1 in RINEX v.2.10) code phase observation",
+                        "UNITS": "m"
+                    }
+                },
+                "P2": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "GPS C2W (P2 in RINEX v.2.10) code phase observation",
+                        "UNITS": "m"
+                    }
+                },
+                "S1_C_N0": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "GPS S1 carrier-to-noise density C/N0",
+                        "UNITS": "dB-Hz"
+                    }
+                },
+                "S2_C_N0": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "GPS S2 carrier-to-noise density C/N0",
+                        "UNITS": "dB-Hz"
+                    }
+                },
+                "Absolute_STEC": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Absolute slant TEC",
+                        "UNITS": "TECU"
+                    }
+                },
+                "Absolute_VTEC": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Absolute vertical TEC",
+                        "UNITS": "TECU"
+                    }
+                },
+                "Elevation_Angle": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Elevation Angle",
+                        "UNITS": "deg"
+                    }
+                },
+                "Relative_STEC": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Relative slant TEC",
+                        "UNITS": "TECU"
+                    }
+                },
+                "Relative_STEC_RMS": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Root mean square error of relative slant TEC",
+                        "UNITS": "TECU"
+                    }
+                },
+                "DCB": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "GPS receiver differential code bias (DCB) (P2-P1)",
+                        "UNITS": "TECU"
+                    }
+                },
+                "DCB_Error": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Post fit RMS of the least square system using pairs of mapped slant TEC",
+                        "UNITS": "TECU"
+                    }
+                }
+            }
+        }
+    },
+    {
+        "name": "GR_TECxTMS_2F",
+        "description": "GRACE ionospheric total electron content",
+        "resourceUrl": "https://swarmhandbook.earth.esa.int/catalogue/GR_TECxTMS_2F",
+        "dataTerms": "This dataset is provided by the European Space Agency and it is subject to terms condition described in https://vires.services/data_terms.",
+        "_order": 27,
+        "fileType": "CDF-generic",
+        "defaultDataset": "TEC_TMS",
+        "datasets": {
+            "TEC_TMS": {
+                "Timestamp": {
+                    "essentialVariable": true,
+                    "primaryTimestamp": true,
+                    "dataType": "timestamp",
+                    "dataSubtype": "CDF_EPOCH",
+                    "attributes": {
+                        "DESCRIPTION": "Time of observation, UTC",
+                        "UNITS": "-"
+                    }
+                },
+                "Latitude": {
+                    "essentialVariable": true,
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Latitude",
+                        "UNITS": "deg"
+                    }
+                },
+                "Longitude": {
+                    "essentialVariable": true,
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Longitude",
+                        "UNITS": "deg"
+                    }
+                },
+                "Radius": {
+                    "essentialVariable": true,
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Radius",
+                        "UNITS": "m"
+                    }
+                },
+                "GPS_Position": {
+                    "dataType": "float64",
+                    "dimension": [3],
+                    "attributes": {
+                        "DESCRIPTION": "X-,Y-,Z-coordinates of the GPS satellite",
+                        "UNITS": "m"
+                    }
+                },
+                "LEO_Position": {
+                    "dataType": "float64",
+                    "dimension": [3],
+                    "attributes": {
+                        "DESCRIPTION": "X-,Y-,Z-coordinates of the LEO satellite",
+                        "UNITS": "m"
+                    }
+                },
+                "PRN": {
+                    "dataType": "uint16",
+                    "attributes": {
+                        "DESCRIPTION": "Pseudorandom noise (PRN) code of GPS satellite",
+                        "UNITS": "-"
+                    }
+                },
+                "L1": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "GPS L1C (LA in RINEX v.2.10) carrier phase observation",
+                        "UNITS": "m"
+                    }
+                },
+                "L2": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "GPS L2W (L2 in RINEX v.2.10) carrier phase observation",
+                        "UNITS": "m"
+                    }
+                },
+                "P1": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "GPS C1W (P1 in RINEX v.2.10) code phase observation",
+                        "UNITS": "m"
+                    }
+                },
+                "P2": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "GPS C2W (P2 in RINEX v.2.10) code phase observation",
+                        "UNITS": "m"
+                    }
+                },
+                "S1_C_N0": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "GPS S1 carrier-to-noise density C/N0",
+                        "UNITS": "dB-Hz"
+                    }
+                },
+                "S2_C_N0": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "GPS S2 carrier-to-noise density C/N0",
+                        "UNITS": "dB-Hz"
+                    }
+                },
+                "Absolute_STEC": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Absolute slant TEC",
+                        "UNITS": "TECU"
+                    }
+                },
+                "Absolute_VTEC": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Absolute vertical TEC",
+                        "UNITS": "TECU"
+                    }
+                },
+                "Elevation_Angle": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Elevation Angle",
+                        "UNITS": "deg"
+                    }
+                },
+                "Relative_STEC": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Relative slant TEC",
+                        "UNITS": "TECU"
+                    }
+                },
+                "Relative_STEC_RMS": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Root mean square error of relative slant TEC",
+                        "UNITS": "TECU"
+                    }
+                },
+                "DCB": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "GPS receiver differential code bias (DCB) (P2-P1)",
+                        "UNITS": "TECU"
+                    }
+                },
+                "DCB_Error": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Post fit RMS of the least square system using pairs of mapped slant TEC",
+                        "UNITS": "TECU"
+                    }
+                }
+            }
+        }
+    },
+    {
+        "name": "GF_TECxTMS_2F",
+        "description": "GRACE-FO ionospheric total electron content",
+        "resourceUrl": "https://swarmhandbook.earth.esa.int/catalogue/GR_TECxTMS_2F",
+        "dataTerms": "This dataset is provided by the European Space Agency and it is subject to terms condition described in https://vires.services/data_terms.",
+        "_order": 27,
+        "fileType": "CDF-generic",
+        "defaultDataset": "TEC_TMS",
+        "datasets": {
+            "TEC_TMS": {
+                "Timestamp": {
+                    "essentialVariable": true,
+                    "primaryTimestamp": true,
+                    "dataType": "timestamp",
+                    "dataSubtype": "CDF_EPOCH",
+                    "attributes": {
+                        "DESCRIPTION": "Time of observation, UTC",
+                        "UNITS": "-"
+                    }
+                },
+                "Latitude": {
+                    "essentialVariable": true,
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Latitude",
+                        "UNITS": "deg"
+                    }
+                },
+                "Longitude": {
+                    "essentialVariable": true,
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Longitude",
+                        "UNITS": "deg"
+                    }
+                },
+                "Radius": {
+                    "essentialVariable": true,
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Position in ITRF - Radius",
+                        "UNITS": "m"
+                    }
+                },
+                "GPS_Position": {
+                    "dataType": "float64",
+                    "dimension": [3],
+                    "attributes": {
+                        "DESCRIPTION": "X-,Y-,Z-coordinates of the GPS satellite",
+                        "UNITS": "m"
+                    }
+                },
+                "LEO_Position": {
+                    "dataType": "float64",
+                    "dimension": [3],
+                    "attributes": {
+                        "DESCRIPTION": "X-,Y-,Z-coordinates of the LEO satellite",
+                        "UNITS": "m"
+                    }
+                },
+                "PRN": {
+                    "dataType": "uint16",
+                    "attributes": {
+                        "DESCRIPTION": "Pseudorandom noise (PRN) code of GPS satellite",
+                        "UNITS": "-"
+                    }
+                },
+                "L1": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "GPS L1C (LA in RINEX v.2.10) carrier phase observation",
+                        "UNITS": "m"
+                    }
+                },
+                "L2": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "GPS L2W (L2 in RINEX v.2.10) carrier phase observation",
+                        "UNITS": "m"
+                    }
+                },
+                "P1": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "GPS C1W (P1 in RINEX v.2.10) code phase observation",
+                        "UNITS": "m"
+                    }
+                },
+                "P2": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "GPS C2W (P2 in RINEX v.2.10) code phase observation",
+                        "UNITS": "m"
+                    }
+                },
+                "S1_C_N0": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "GPS S1 carrier-to-noise density C/N0",
+                        "UNITS": "dB-Hz"
+                    }
+                },
+                "S2_C_N0": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "GPS S2 carrier-to-noise density C/N0",
+                        "UNITS": "dB-Hz"
+                    }
+                },
+                "Absolute_STEC": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Absolute slant TEC",
+                        "UNITS": "TECU"
+                    }
+                },
+                "Absolute_VTEC": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Absolute vertical TEC",
+                        "UNITS": "TECU"
+                    }
+                },
+                "Elevation_Angle": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Elevation Angle",
+                        "UNITS": "deg"
+                    }
+                },
+                "Relative_STEC": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Relative slant TEC",
+                        "UNITS": "TECU"
+                    }
+                },
+                "Relative_STEC_RMS": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Root mean square error of relative slant TEC",
+                        "UNITS": "TECU"
+                    }
+                },
+                "DCB": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "GPS receiver differential code bias (DCB) (P2-P1)",
+                        "UNITS": "TECU"
+                    }
+                },
+                "DCB_Error": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Post fit RMS of the least square system using pairs of mapped slant TEC",
+                        "UNITS": "TECU"
+                    }
+                }
+            }
+        }
+    },
+    {
+        "name": "GR_NE__KBR_2F",
+        "description": "GRACE dual spacecraft average electron density",
+        "resourceUrl": "https://swarmhandbook.earth.esa.int/catalogue/GR_NE__KBR_2F",
+        "dataTerms": "This dataset is provided by the European Space Agency and it is subject to terms condition described in https://vires.services/data_terms.",
+        "_order": 28,
+        "fileType": "CDF-generic",
+        "defaultDataset": "NE__KBR",
+        "datasets": {
+            "NE__KBR": {
+                "Timestamp": {
+                    "essentialVariable": true,
+                    "primaryTimestamp": true,
+                    "dataType": "timestamp",
+                    "dataSubtype": "CDF_EPOCH",
+                    "attributes": {
+                        "DESCRIPTION": "Time of observation, UTC",
+                        "UNITS": "-"
+                    }
+                },
+                "Latitude": {
+                    "essentialVariable": true,
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Middle point position between satellites in ITRF - Latitude",
+                        "UNITS": "deg"
+                    }
+                },
+                "Longitude": {
+                    "essentialVariable": true,
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Middle point position between satellites in ITRF - Longitude",
+                        "UNITS": "deg"
+                    }
+                },
+                "Radius": {
+                    "essentialVariable": true,
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Middle point position between satellites in ITRF - Radius",
+                        "UNITS": "m"
+                    }
+                },
+                "LEO_Position": {
+                    "dataType": "float64",
+                    "dimension": [2, 3],
+                    "attributes": {
+                        "DESCRIPTION": "X-, Y-, Z-coordinates of the satellites",
+                        "UNITS": "m"
+                    }
+                },
+                "Distance": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Distance between satellites",
+                        "UNITS": "m"
+                    }
+                },
+                "Relative_Hor_TEC": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Relative horizontal TEC between satellites",
+                        "UNITS": "TECU"
+                    }
+                },
+                "Relative_Ne": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean relative electron density of the area between satellites",
+                        "UNITS": "1/cm^3"
+                    }
+                },
+                "Absolute_Ne": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Electron density between satellites",
+                        "UNITS": "1/cm^3"
+                    }
+                }
+            }
+        }
+    },
+    {
+        "name": "GF_NE__KBR_2F",
+        "description": "GRACE-FO dual spacecraft average electron density",
+        "resourceUrl": "https://swarmhandbook.earth.esa.int/catalogue/GF_NE__KBR_2F",
+        "dataTerms": "This dataset is provided by the European Space Agency and it is subject to terms condition described in https://vires.services/data_terms.",
+        "_order": 28,
+        "fileType": "CDF-generic",
+        "defaultDataset": "NE__KBR",
+        "datasets": {
+            "NE__KBR": {
+                "Timestamp": {
+                    "essentialVariable": true,
+                    "primaryTimestamp": true,
+                    "dataType": "timestamp",
+                    "dataSubtype": "CDF_EPOCH",
+                    "attributes": {
+                        "DESCRIPTION": "Time of observation, UTC",
+                        "UNITS": "-"
+                    }
+                },
+                "Latitude": {
+                    "essentialVariable": true,
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Middle point position between satellites in ITRF - Latitude",
+                        "UNITS": "deg"
+                    }
+                },
+                "Longitude": {
+                    "essentialVariable": true,
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Middle point position between satellites in ITRF - Longitude",
+                        "UNITS": "deg"
+                    }
+                },
+                "Radius": {
+                    "essentialVariable": true,
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Middle point position between satellites in ITRF - Radius",
+                        "UNITS": "m"
+                    }
+                },
+                "LEO_Position": {
+                    "dataType": "float64",
+                    "dimension": [2, 3],
+                    "attributes": {
+                        "DESCRIPTION": "X-, Y-, Z-coordinates of the satellites",
+                        "UNITS": "m"
+                    }
+                },
+                "Distance": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Distance between satellites",
+                        "UNITS": "m"
+                    }
+                },
+                "Relative_Hor_TEC": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Relative horizontal TEC between satellites",
+                        "UNITS": "TECU"
+                    }
+                },
+                "Relative_Ne": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Mean relative electron density of the area between satellites",
+                        "UNITS": "1/cm^3"
+                    }
+                },
+                "Absolute_Ne": {
+                    "dataType": "float64",
+                    "attributes": {
+                        "DESCRIPTION": "Electron density between satellites",
+                        "UNITS": "1/cm^3"
+                    }
+                }
+            }
+        }
+    },
+    {
         "name": "SW_NIX_TMS_2F",
         "description": "Swarm electron density gradient ionosphere index (NEGIX)",
         "resourceUrl": "https://swarmhandbook.earth.esa.int/catalogue/SW_NIX_TMS_2F",
         "dataTerms": "This dataset is provided by the European Space Agency and it is subject to terms condition described in https://vires.services/data_terms.",
-        "_order": 28,
+        "_order": 29,
         "fileType": "CDF-generic",
         "defaultDataset": "NIX_TMS",
         "datasets": {
@@ -1763,7 +2412,7 @@
         "description": "Swarm total electron content (TEC) gradient ionosphere index (TEGIX)",
         "resourceUrl": "https://swarmhandbook.earth.esa.int/catalogue/SW_TIX_TMS_2F",
         "dataTerms": "This dataset is provided by the European Space Agency and it is subject to terms condition described in https://vires.services/data_terms.",
-        "_order": 28,
+        "_order": 29,
         "fileType": "CDF-generic",
         "defaultDataset": "TIX_TMS",
         "datasets": {

--- a/vires/vires/metadata/__init__.py
+++ b/vires/vires/metadata/__init__.py
@@ -28,6 +28,7 @@
 
 from .base import MetadataReader
 from .cdf.generic import GenericCdfMetadataReader
+from .cdf.time_span import TimeSpanCdfMetadataReader
 from .cdf.obs import ObsCdfMetadataReader
 from .cdf.vobs import VobsCdfMetadataReader
 from .cdf.con_eph import ConEphCdfMetadataReader
@@ -39,6 +40,7 @@ METADATA_READERS = {
         reader.TYPE: reader
         for reader in [
             GenericCdfMetadataReader,
+            TimeSpanCdfMetadataReader,
             ObsCdfMetadataReader,
             VobsCdfMetadataReader,
             ConEphCdfMetadataReader,

--- a/vires/vires/metadata/cdf/time_span.py
+++ b/vires/vires/metadata/cdf/time_span.py
@@ -1,0 +1,90 @@
+#-------------------------------------------------------------------------------
+#
+# Products metadata extraction -
+# CDF metadata reader for datasets with annotated time-span attribute.
+#
+# Authors: Martin Paces <martin.paces@eox.at>
+#-------------------------------------------------------------------------------
+# Copyright (C) 2025 EOX IT Services GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies of this Software or works derived from this Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#-------------------------------------------------------------------------------
+# pylint: disable=missing-docstring
+
+import re
+from datetime import datetime, timedelta
+from vires.time_util import naive_to_utc
+from .base import CDFMetadataReader
+
+MAX_SUBSECOND = timedelta(seconds=1) - timedelta(microseconds=1)
+
+
+class TimeSpanCdfMetadataReader(CDFMetadataReader):
+    """ Metadata reader for CDF files with annotated time-span as global
+    CDF attribute.
+    """
+    TYPE = "CDF-with-timespan-attribute"
+    DEFAULT_TIMESPAN_ATTRIBUTE = "Timespan"
+    RE_TIMESTAMP = re.compile(
+        r'^UTC=(?P<year>\d{4,4})-(?P<month>\d{2,2})-(?P<day>\d{2,2})T'
+        r'(?P<hour>\d{2,2}):(?P<minute>\d{2,2}):(?P<second>\d{2,2})$'
+    )
+
+    @classmethod
+    def extract_options(cls, product_type):
+        """ Extract optional non-default timespan attribute name. """
+        return {
+            "attribute_name": product_type.definition.get(
+                "timespanAttributeName", cls.DEFAULT_TIMESPAN_ATTRIBUTE
+            )
+        }
+
+    @classmethod
+    def read_cdf_metadata(cls, cdf, **options):
+        begin_time, end_time = cls._read_timespan_attribute(
+            cdf, attribute_name=options["attribute_name"]
+        )
+        return {
+            "format": cls.TYPE,
+            "begin_time": begin_time,
+            "end_time": end_time,
+        }
+
+    @classmethod
+    def _read_timespan_attribute(cls, cdf, attribute_name):
+
+        try:
+            start, end = cdf.attrs[attribute_name]
+        except (KeyError, ValueError, TypeError):
+            raise ValueError(
+                f"Failed to read the {attribute_name} global attribute!"
+            ) from None
+
+        return (
+            cls._parse_utc_timestamp(start),
+            cls._parse_utc_timestamp(end) + MAX_SUBSECOND,
+        )
+
+    @classmethod
+    def _parse_utc_timestamp(cls, value):
+        if not (match := cls.RE_TIMESTAMP.match(value)):
+            raise ValueError(f"Invalid timestamp value {value}!")
+        return naive_to_utc(datetime(**{
+            key: int(value) for key, value in match.groupdict().items()
+        }))

--- a/vires/vires/processes/util/time_series/data_extraction.py
+++ b/vires/vires/processes/util/time_series/data_extraction.py
@@ -140,7 +140,7 @@ class CDFDataset:
             )
 
         if max_record_duration is None:
-            raise ValueError("Missing mandatory max. record")
+            raise ValueError("Missing mandatory maximum record duration.")
 
         # empty dataset
         if start_times.size == 0:


### PR DESCRIPTION
Adding ULF, MIGRAS and TIRO products to production.

This is mostly configuration and documentation change, except the new metadata extractor needed by the ULF products.