### PR TITLE
Hotfix: Fixing HAPI CSS reflection

### DIFF
--- a/vires/vires/hapi/views/common.py
+++ b/vires/vires/hapi/views/common.py
@@ -28,6 +28,7 @@
 #-------------------------------------------------------------------------------
 # pylint: disable=missing-docstring,too-few-public-methods
 
+import re
 from logging import getLogger
 from traceback import format_exc
 from datetime import datetime, time
@@ -139,7 +140,8 @@ def allowed_parameters(*allowed_parameters):
             extra_parameters = set(request.GET.keys()) - allowed_parameters
             if extra_parameters:
                 raise HapiError(hapi_status=1401, message=(
-                    f"unexpected request parameter '{next(iter(extra_parameters))}'"
+                    "unexpected request parameter "
+                    f"'{sanitize_response_value(next(iter(extra_parameters)))}'"
                 ))
             return view(request, *args, **kwargs)
         return _check_allowed_parameters
@@ -195,4 +197,14 @@ def parse_datetime(value):
     parsed_value = django_parse_date(value)
     if parsed_value is not None:
         return naive_to_utc(datetime.combine(parsed_value, time()))
-    raise ValueError(f"invalid time {value}'")
+    raise ValueError(f"invalid time {sanitize_response_value(value)}'")
+
+
+def sanitize_response_value(value, max_size=128):
+    """ Sanitize response value value to not contain any special
+    white-space characters and clip it to the allowed maximum size.
+    """
+    sanitized_value = str(value)[:max_size]
+    if len(sanitized_value) < len(value):
+        sanitized_value = f"{sanitized_value}..."
+    return re.sub(r'\s', ' ', value)

--- a/vires/vires/hapi/views/info.py
+++ b/vires/vires/hapi/views/info.py
@@ -37,7 +37,8 @@ from ..formats.common import get_datetime64_string_size
 from ..data_type import parse_data_type
 from .common import (
     HapiResponse, HapiError,
-    catch_error, allowed_parameters, required_parameters, map_parameters
+    catch_error, allowed_parameters, required_parameters, map_parameters,
+    sanitize_response_value,
 )
 
 EXTRA_METADATA_FIELDS = [
@@ -172,7 +173,9 @@ def _parse_parameters(requested_parameters, dataset_definition):
         parameters_set = set(parameters)
 
         for parameter in parameters_set - set(definition):
-            raise ValueError(f"invalid parameter {parameter}")
+            raise ValueError(
+                f"invalid parameter {sanitize_response_value(parameter)}"
+            )
 
         if len(parameters_set) < len(parameters):
             for parameter in _find_duplicates(parameters):


### PR DESCRIPTION
Improved handling of the request parameters:
- incorrect user input (query parameters) must not be included in the HTTP response status message
- when included in the response body, the user input (incorrect query parameters) must not be interpreted as HTML + script